### PR TITLE
Fixed CSS scrolling

### DIFF
--- a/htroot/env/bootstrap-base.css
+++ b/htroot/env/bootstrap-base.css
@@ -35,7 +35,7 @@ body {
     display: block;
     padding: 20px;
     overflow-x: hidden;
-    overflow-y: auto; /* Scrollable contents if viewport is shorter than content. */
+    overflow-y: scroll;
   }
 }
 
@@ -123,4 +123,7 @@ ul.nav li.dropdown:hover ul.dropdown-menu{
 .popover {
     z-index: 1600;
 }
- 
+.col-md-9 {
+    width: auto;
+    overflow-x: hidden;
+}


### PR DESCRIPTION
When the sidebar on search page becomes scrollable, the scrollbar shrinks the sidebar and makes the search results weirdly scrollable on X axis by several pixels. Now the sidebar always have a scrollbar, and results are never X-scrollable.