### PR TITLE
Modified images render error management

### DIFF
--- a/source/net/yacy/http/servlets/YaCyDefaultServlet.java
+++ b/source/net/yacy/http/servlets/YaCyDefaultServlet.java
@@ -851,6 +851,13 @@ public class YaCyDefaultServlet extends HttpServlet  {
                 } else if (tmp instanceof EncodedImage) {
                     final EncodedImage yp = (EncodedImage) tmp;
                     result = yp.getImage();
+                    /** When encodedImage is empty, return a code 500 rather than only an empty response 
+                     * as it is better handled across different browsers */
+                    if(result == null || result.length() == 0) {
+                    	response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+                    	result.close();
+                    	return;
+                    }
                     if (yp.isStatic()) {
                         response.setDateHeader(HeaderFramework.EXPIRES, now + 600000); // expires in ten minutes
                     }
@@ -1004,6 +1011,11 @@ public class YaCyDefaultServlet extends HttpServlet  {
 				size += l;
 			}
 			response.setContentLength(size);
+		} catch(IOException e){
+			/** No need to log full stack trace (in most cases resource is not available because of a network error) */
+			ConcurrentLog.fine("FILEHANDLER", "YaCyDefaultServlet: resource content stream could not be written to response.");
+        	response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        	return;
 		} finally {
 			try {
 				inStream.close();


### PR DESCRIPTION
As noticed by Orbiter, with last recent code modifications, to much Exceptions may be logged when searching images. Modified it to keep consistent behavior but to log only useful information.

A HTTP 500 code is still returned when a rendering image error occured, which better handled across browsers than HTTP 200 code with a null content.(for example Konqueror and Chromium didn't fall back to default favicon when a null image content was returned)