### PR TITLE
Prevent start scripts to fail silently when yacycore.jar was not built.

### DIFF
--- a/startYACY.bat
+++ b/startYACY.bat
@@ -7,6 +7,11 @@ echo . >DATA\yacy.noconsole
 
 Rem Setting the classpath
 Set CLASSPATH=lib\yacycore.jar
+Rem Check core jar exists to avoid failing silently later
+if not exist lib/yacycore.jar (
+	Echo "Error : lib/yacycore.jar was not found! Please first build from sources using Apache Ant."
+	Exit /b 1
+)
 
 REM Please change the "javastart" settings in the web-interface "Basic Configuration" -> "Advanced" 
 set jmx=

--- a/startYACY.sh
+++ b/startYACY.sh
@@ -188,6 +188,13 @@ CLASSPATH=""
 for N in lib/*.jar; do CLASSPATH="$CLASSPATH$N:"; done
 CLASSPATH=".:htroot:$CLASSPATH"
 
+# check core jar exists to avoid failing silently later
+if [ ! -f lib/yacycore.jar ]
+then
+   echo "Error: lib/yacycore.jar was not found! Please first build from sources using Apache Ant."
+   exit 1
+fi
+
 cmdline="$JAVA $JAVA_ARGS -classpath $CLASSPATH net.yacy.yacy";
 if [ $GUI -eq 1 ] #gui
 then

--- a/startYACY_debug.bat
+++ b/startYACY_debug.bat
@@ -5,6 +5,11 @@ if exist DATA\yacy.noconsole del DATA\yacy.noconsole
 
 Rem Generating the proper classpath unsing loops and labels
 Set CLASSPATH=lib/yacycore.jar;htroot
+Rem Check core jar exists to avoid failing silently later
+if not exist lib/yacycore.jar (
+	Echo "Error : lib/yacycore.jar was not found! Please first build from sources using Apache Ant."
+	Exit /b 1
+)
 
 REM Please change the "javastart" settings in the web-interface "Basic Configuration" -> "Advanced" 
 set jmx=

--- a/stopYACY.bat
+++ b/stopYACY.bat
@@ -3,6 +3,11 @@ title YaCy
 
 Rem Setting the classpath
 Set CLASSPATH=lib\yacycore.jar
+Rem Check core jar exists to avoid failing silently later
+if not exist lib/yacycore.jar (
+	Echo "Error : lib/yacycore.jar was not found! Please first build from sources using Apache Ant."
+	Exit /b 1
+)
 
 Rem Stopping yacy
 Echo Generated Classpath:%CLASSPATH%


### PR DESCRIPTION
Added a check for lib/yacycore.jar file, eventually followed by an error message and an exit status 1. 

Because one can easily forget yacycore.jar was not built, for example just after getting sources from github without and IDE or after a "ant clean" : it was then confusing to see  message such as "YaCy started as daemon process." and nothing happens.