### PR TITLE
Fix multiple boost queries

### DIFF
--- a/defaults/yacy.init
+++ b/defaults/yacy.init
@@ -1036,7 +1036,7 @@ search.ranking.rwi.profile =
 search.ranking.solr.collection.boostname.tmpa.0=Default Profile
 search.ranking.solr.collection.boostfields.tmpa.0=url_paths_sxt^3.0,synonyms_sxt^0.5,title^5.0,text_t^1.0,host_s^6.0,h1_txt^5.0,url_file_name_tokens_t^4.0,h2_txt^3.0,keywords^2.0,description_txt^1.5,author^1.0
 search.ranking.solr.collection.filterquery.tmpa.0=
-search.ranking.solr.collection.boostquery.tmpa.0=crawldepth_i:0^0.8 crawldepth_i:1^0.4
+search.ranking.solr.collection.boostquery.tmpa.0=crawldepth_i:0^0.8\ncrawldepth_i:1^0.4
 search.ranking.solr.collection.boostfunction.tmpb.0=
 search.ranking.solr.collection.boostname.tmpa.1=Date Profile: sort by date in descending order for a '/date' usage
 search.ranking.solr.collection.boostfields.tmpa.1=url_paths_sxt^0.1,title^0.1,text_t^0.1
@@ -1051,7 +1051,7 @@ search.ranking.solr.collection.boostfunction.tmpb.2=
 search.ranking.solr.collection.boostname.tmpa.3=_unused3
 search.ranking.solr.collection.boostfields.tmpa.3=text_t^1.0
 search.ranking.solr.collection.filterquery.tmpa.3=
-search.ranking.solr.collection.boostquery.tmpa.3=crawldepth_i:0^0.8 crawldepth_i:1^0.4
+search.ranking.solr.collection.boostquery.tmpa.3=crawldepth_i:0^0.8\ncrawldepth_i:1^0.4
 search.ranking.solr.collection.boostfunction.tmpb.3=
 
 # the following values are used to identify duplicate content

--- a/htroot/RankingSolr_p.html
+++ b/htroot/RankingSolr_p.html
@@ -50,7 +50,7 @@
         <dl>
           <dt style="width:260px;margin:0;padding:0;height:1.8em;"><label for="bq" id="bq_label">bq=</label></dt>
           <dd style="width:360px;margin:0;padding:0;float:left;display:inline;" id="bq_dd">
-            <textarea name="bq" id="bq" align="left" cols="96" rows="1"/>#[bq]#</textarea>
+            <textarea name="bq" id="bq" align="left" cols="96" rows="5"/>#[bq]#</textarea>
           </dd>
           <dt style="width:260px;margin:0;padding:0;height:1.8em;"></dt>
           <dd style="width:360px;margin:0;padding:0;height:1.8em;float:left;display:inline;">

--- a/htroot/RankingSolr_p.java
+++ b/htroot/RankingSolr_p.java
@@ -97,7 +97,7 @@ public class RankingSolr_p {
             }
         }
         if (post != null && post.containsKey("ResetBQ")) {
-            String bq = "crawldepth_i:0^0.8 crawldepth_i:1^0.4";
+            String bq = "crawldepth_i:0^0.8\ncrawldepth_i:1^0.4";
             if (bq != null) {
                 sb.setConfig(SwitchboardConstants.SEARCH_RANKING_SOLR_COLLECTION_BOOSTQUERY_ + profileNr, bq);
                 sb.index.fulltext().getDefaultConfiguration().getRanking(profileNr).setBoostQuery(bq);

--- a/source/net/yacy/search/Switchboard.java
+++ b/source/net/yacy/search/Switchboard.java
@@ -537,6 +537,7 @@ public final class Switchboard extends serverSwitch {
                 bf.equals("scale(cr_host_norm_i,1,20)")) bf = "";
             if (bf.equals("recip(rord(last_modified),1,1000,1000))")) bf = "recip(ms(NOW,last_modified),3.16e-11,1,1)"; // that was an outdated date boost that did not work well
             if (i == 0 && bq.equals("fuzzy_signature_unique_b:true^100000.0")) bq = "crawldepth_i:0^0.8 crawldepth_i:1^0.4";
+            if (bq.equals("crawldepth_i:0^0.8 crawldepth_i:1^0.4")) bq = "crawldepth_i:0^0.8\ncrawldepth_i:1^0.4"; // Fix issue with multiple Boost Queries
             if (boosts.equals("url_paths_sxt^1000.0,synonyms_sxt^1.0,title^10000.0,text_t^2.0,h1_txt^1000.0,h2_txt^100.0,host_organization_s^100000.0")) boosts = "url_paths_sxt^3.0,synonyms_sxt^0.5,title^5.0,text_t^1.0,host_s^6.0,h1_txt^5.0,url_file_name_tokens_t^4.0,h2_txt^2.0";
             r.setName(name);
             r.updateBoosts(boosts);

--- a/source/net/yacy/search/query/QueryParams.java
+++ b/source/net/yacy/search/query/QueryParams.java
@@ -386,7 +386,7 @@ public final class QueryParams {
         if (!qf.isEmpty()) params.setParam(DisMaxParams.QF, qf);
         if (this.queryGoal.getIncludeSize() > 1) {
             // add boost on combined words
-            if (bq.length() > 0) bq += " ";
+            if (bq.length() > 0) bq += "\n";
             bq += CollectionSchema.text_t.getSolrFieldName() + ":\"" + this.queryGoal.getIncludeString() + "\"^10";
         }
         if (fq.length() > 0) {
@@ -396,7 +396,7 @@ public final class QueryParams {
             newfq.add(fq);
             params.setFilterQueries(newfq.toArray(new String[newfq.size()]));
         }
-        if (bq.length() > 0) params.setParam(DisMaxParams.BQ, bq);
+        if (bq.length() > 0) params.setParam(DisMaxParams.BQ, bq.split("[\\r\\n]+")); // split on any sequence consisting of CR and/or LF
         if (bf.length() > 0) params.setParam("boost", bf); // a boost function extension, see http://wiki.apache.org/solr/ExtendedDisMax#bf_.28Boost_Function.2C_additive.29
         
         // prepare result


### PR DESCRIPTION
Multiple Boost Queries (e.g. the default setting that YaCy uses for Boost Queries) are broken in YaCy right now.  See my writeup at https://gist.github.com/JeremyRand/39d0d77407d651539c7bb920b668d91e for details on what exactly is wrong.

This PR fixes the issue by allowing multiple Boost Queries to be specified, one on each line.

As a prerequisite, I had to refactor the escaping code that YaCy's config file read/write code uses, because it was failing to properly escape newlines (and its usage of RegEx was unnecessarily complex and difficult to read).  I haven't measured performance, but I think it's likely that the refactored code will be faster, because standard string search operations are much less computationally complex than RegEx operations.

If you need, I can provide the refactored escaping code in a separate PR.  I don't think this is needed, since it's already in a separate commit.