### PR TITLE
Use aria role to reduce rssTerminal verbosity.

### DIFF
--- a/htroot/rssTerminal.html
+++ b/htroot/rssTerminal.html
@@ -1,7 +1,7 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+<meta charset="UTF-8">
 <title>rss terminal</title>
 <style type="text/css">
 
@@ -172,7 +172,7 @@ function init() {
 
 <body onload="self.getURLparameters();init();">
   <div id="feedbox">
-      <p id="content"></p>
+      <p id="content" role="marquee"></p>
   </div>
 </body>
 


### PR DESCRIPTION
This is a fix for http://mantis.tokeek.de/view.php?id=643

Tested with NVDA (http://www.nvaccess.org/) screenreader with firefox on Windows 7.