### PR TITLE
Update debian dependency to allow installing with java 1.8

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,8 @@ Standards-Version: 3.7.2
 
 Package: yacy
 Architecture: all
-Depends: openjdk-7-jre-headless, sudo, debconf
+Depends: openjdk-7-jre-headless | openjdk-8-jre-headless, sudo, debconf
+Suggests: curl | wget
 Description: Peer-to-Peer Web Search Engine
  YaCy is a Java-based peer-to-peer search engine.
  It provides a personal web search engine, which is

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 3.7.2
 
 Package: yacy
 Architecture: all
-Depends: openjdk-7-jre-headless | openjdk-8-jre-headless, sudo, debconf
+Depends: java7-runtime-headless | java8-runtime-headless, sudo, debconf
 Suggests: curl | wget
 Description: Peer-to-Peer Web Search Engine
  YaCy is a Java-based peer-to-peer search engine.


### PR DESCRIPTION
YaCy is currently working with java 1.8 on Debian, but its debian package dependencies are too restrictive : 
 - can not install on a Debian machine having only a jre or jdk 1.8 (for example a Debian testing (Stretch))
- can not install on a Debian machine having only Oracle provided jre

I updated yacy debian/control file to allow install with apt on any machine having a java 1.7 OR a java 1.8 runtime.

Test procedure :
 - build on Debian Jessie with openjdk-7
 - installed and run successfully on :
  - Debian Jessie with only openjdk-7-jre-headless
  - Debian Stretch with only oracle-java8-jdk_8u91_amd64 build with make-jpkg from Oracle jdk-8u91-linux-x64.tar.gz
  - Debian Stretch with only openjdk-8-jre-headless