### PR TITLE
Make YaCy usable on small screen devices

### DIFF
--- a/htroot/env/templates/metas.template
+++ b/htroot/env/templates/metas.template
@@ -5,6 +5,9 @@
   <meta name="description" content="Software HTTP Freeware Home Page" />
   <meta name="copyright" content="Michael Christen et al." />
   
+  <!-- Ensure proper rendering and touch zooming on mobile devices -->
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  
   <!-- Bootstrap core CSS -->
   <link href="/env/bootstrap/css/bootstrap.min.css" rel="stylesheet">
   <link href="/env/bootstrap/css/bootstrap-switch.min.css" rel="stylesheet">


### PR DESCRIPTION
YaCy web interface is almost impossible to use on many mobile devices because rendering far too small. Thus you always have to zoom in to use it. It is especially true for low end android devices.

I propose here a first fix with low regression risk, impacting only mobile devices : add of meta tag "viewport" as recommended by bootstrap (http://getbootstrap.com/css/#overview-mobile). This effectively seems to improve rendering on many devices.

Tested with :
- real physical device : Samsung GT-S5360 with android 2.3.6
- Browser stack mobile devices (see http://mantis.tokeek.de/view.php?id=628 for screenshots)
- Chromium device toolbar