### PR TITLE
Opensearch : fix for default ports and naming consistency

### DIFF
--- a/htroot/opensearchdescription.java
+++ b/htroot/opensearchdescription.java
@@ -25,6 +25,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 import net.yacy.cora.protocol.Domains;
+import net.yacy.cora.protocol.HeaderFramework;
 import net.yacy.cora.protocol.RequestHeader;
 import net.yacy.search.Switchboard;
 import net.yacy.search.SwitchboardConstants;
@@ -39,7 +40,7 @@ public class opensearchdescription {
         String promoteSearchPageGreeting = env.getConfig(SwitchboardConstants.GREETING, "");
         if (env.getConfigBool(SwitchboardConstants.GREETING_NETWORK_NAME, false)) promoteSearchPageGreeting = env.getConfig("network.unit.description", "");
 
-        String thisaddress = header.get("Host"); // returns host:port (if not defalt http/https ports)
+        String thisaddress = header.get(HeaderFramework.HOST); // returns host:port (if not default http/https ports)
         String thisprotocol = "http";
         if (thisaddress == null) {
             thisaddress = Domains.LOCALHOST + ":" + sb.getConfig("port", "8090");
@@ -49,6 +50,9 @@ public class opensearchdescription {
                 thisprotocol = "https";
             }
         }
+        /* YaCyDefaultServelt should have filled this custom header, making sure we know here wether original request is http or https
+         *  (when default ports (80 and 443) are used, there is no way to distinguish the two schemes relying only on the Host header) */
+        thisprotocol = header.get(HeaderFramework.X_YACY_REQUEST_SCHEME, thisprotocol);
         
         final serverObjects prop = new serverObjects();
         prop.put("compareyacy", post != null && post.getBoolean("compare_yacy") ? 1 : 0);

--- a/htroot/opensearchdescription.xml
+++ b/htroot/opensearchdescription.xml
@@ -2,7 +2,7 @@
 <OpenSearchDescription
     xmlns="http://a9.com/-/spec/opensearch/1.1/"
     xmlns:suggestions="http://www.opensearch.org/specifications/opensearch/extensions/suggestions/1.1">
-  <ShortName>#(compareyacy)#::Compare #(/compareyacy)#YaCy/#[clientname]#</ShortName>
+  <ShortName>#(compareyacy)#::Compare #(/compareyacy)#YaCy Search on '#[clientname]#'</ShortName>
   <LongName>YaCy.net - #[SearchPageGreeting]#</LongName>
   <Image type="image/gif">#[thisprotocol]#://#[thisaddress]#/env/grafics/yacy.png</Image>
   <Image width="16" height="16">data:image/x-icon;base64,AAABAAEAEBAAAAAAGABoAwAAFgAAACgAAAAQAAAAIAAAAAEAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD////////Chiu+fBm+fRq+fRq+fRq+fRq+fRq8ehXMmk////////////////////////////++exjUqGfZsnjYsXbYsXbYsXbZsnjTp2W+fBr///////////////////////////+9exfs2r/69/L58+z58+z58+z59e/z59bChSn///////////////////////////+9fBnnz638+fX69O369e748un38Ob59O3Ll0fVrGz////////////////////////Jk0HJlUjXuYrWt4jVtYPr28T58+r59OzPn1fPnlX////////////////////////Rolu8eRXCiTPEjTvCijbNnlj169359e7Zs3vLlkf////////////////////////UqmrAgSLt3MP27eH1693169327+T59Ozo0rG/gB////////////////////////////+/gCDv4Mn48+v38Of59Oz58+v48+vr2b2+fRv///////////////////////////+9ehXr17n58+z48ejo0bDp07T48+zx49DBhCj///////////////////////////+/fhzjyJ/59Oz59OzQoVvNmU759Oz58+vKlUbXrnH////////////////////////LlkfUqmn59Oz48+vZtHzNm1D48+v59OzPoFjOnlX////////////////////////OnVPOnFL59e348+vq1rnEiC7u38j69vDXsHTIkT3////////////////////////UqWjIkD327+T58+3s2bzAgSLp07T79/Pmzqq+fBn///////////////////////////+/fx7v4Mr7+PTx5NDHkD3kyqP8+vjs2r+9exf///////////////////////////++fBjQoFnVq2zTp2bGjTjJk0LWrW7SpWC+exf////////////////////////////Nm1C6dQy7eBG8eBK9exe8ehS7dxC6dQzLlkj////////////AH///wB8x+sAf///AD/+PwA///8AP///AD///4A9PU+APoz/gB///4AdxvOAHoz/gB3368AfjU/AHT1PwB/+P
@@ -17,7 +17,7 @@
   <Url type="application/rss+xml" method="GET" template="#[thisprotocol]#://#[thisaddress]#/yacysearch.rss?nav=&amp;query={searchTerms}&amp;startRecord={startIndex?}&amp;maximumRecords={count?}&amp;nav=all&amp;resource=global" />
   <Url type="application/atom+xml" method="GET" template="#[thisprotocol]#://#[thisaddress]#/yacysearch.atom?query={searchTerms}&amp;startRecord={startIndex?}&amp;maximumRecords={count?}&amp;resource=global" />
   ::
-  <Url type="text/html" method="GET" template="http://#[thisaddress]#/compare_yacy.html?query={searchTerms}&amp;left=#[search_left]#&amp;right=#[search_right]#&amp;display=2" />
+  <Url type="text/html" method="GET" template="#[thisprotocol]#://#[thisaddress]#/compare_yacy.html?query={searchTerms}&amp;left=#[search_left]#&amp;right=#[search_right]#&amp;display=2" />
   #(/compareyacy)#
   <Url type="application/x-suggestions+json" template="#[thisprotocol]#://#[thisaddress]#/suggest.json?query={searchTerms}"/>
   <Url type="application/x-suggestions+xml" template="#[thisprotocol]#://#[thisaddress]#/suggest.xml?query={searchTerms}"/>

--- a/source/net/yacy/cora/protocol/HeaderFramework.java
+++ b/source/net/yacy/cora/protocol/HeaderFramework.java
@@ -113,6 +113,8 @@ public class HeaderFramework extends TreeMap<String, String> implements Map<Stri
     public static final String X_YACY_ORIGINAL_REQUEST_LINE = "X-Original-Request-Line";
     public static final String X_YACY_MEDIA_TITLE = "X-YaCy-Media-Title"; // can be attached to media files which do not have metadata; this will be used as title
     public static final String X_YACY_MEDIA_KEYWORDS = "X-YaCy-Media-Keywords"; // can be attached to media files which do not have metadata; this will be used as keywords (space-separared list of words)
+    /** Added when generating legacy request header to allow template servlets to know the original request scheme : "http" or "https" */
+    public static final String X_YACY_REQUEST_SCHEME = "X-YaCy-Request-Scheme";
 
     public static final String SET_COOKIE = "Set-Cookie";
     public static final String SET_COOKIE2 = "Set-Cookie2";

--- a/source/net/yacy/http/servlets/YaCyDefaultServlet.java
+++ b/source/net/yacy/http/servlets/YaCyDefaultServlet.java
@@ -686,6 +686,9 @@ public class YaCyDefaultServlet extends HttpServlet  {
         legacyRequestHeader.put(HeaderFramework.CONNECTION_PROP_CLIENTIP, request.getRemoteAddr());
         legacyRequestHeader.put(HeaderFramework.CONNECTION_PROP_PATH, target);
         legacyRequestHeader.put(HeaderFramework.CONNECTION_PROP_EXT, targetExt);
+        /* Add request scheme (http or https) to allow templates to know wether original request is http or https 
+         * (when default ports (80 and 443) are used, there is no way to distinguish the two schemes relying only on the Host header) */
+        legacyRequestHeader.put(HeaderFramework.X_YACY_REQUEST_SCHEME, request.getScheme());
         Switchboard sb = Switchboard.getSwitchboard();
         if (legacyRequestHeader.containsKey(RequestHeader.AUTHORIZATION)) {
             if (HttpServletRequest.BASIC_AUTH.equalsIgnoreCase(request.getAuthType())) {


### PR DESCRIPTION
Handle correctly Opensearch description URLs when YaCy is bound on default HTTP and HTTPS ports, respectively 80 and 443. This extends improvements already made for mantis 669 (http://mantis.tokeek.de/view.php?id=669).

Also fixed Opensearch naming consistency between descriptor ('ShortName' field) and HTML search link ('title' attribute), causing incorrect behavior on Firefox as reported in mantis 679 (http://mantis.tokeek.de/view.php?id=679).

Test platform :
- YaCy peer running on Linux Debian Jessie
- Browsers : 
  - Firefox 45.3.0 on Debian Jessie
  - Firefox 47.0.1 on Microsoft Windows 10
  - Chrome 52.0.2743  on Microsoft Windows 10