### PR TITLE
Fixed HTTPS  mixed content warnings and errors

### DIFF
--- a/htroot/ConfigPortal.html
+++ b/htroot/ConfigPortal.html
@@ -146,7 +146,7 @@
     </pre></fieldset>
     This would look like:
     <iframe name="target"
-       src="http://#[myPreviewAddress]#/index.html?display=2&amp;resource=local&amp;focus=0"
+       src="#[myPreviewProtocol]#://#[myPreviewAddress]#/index.html?display=2&amp;resource=local&amp;focus=0"
        width="100%"
        height="410"
        frameborder="0"
@@ -169,7 +169,7 @@
     </pre></fieldset>
     This would look like:
     <iframe name="target2"
-       src="http://#[myPreviewAddress]#/yacysearch.html?display=2&amp;resource=local&amp;focus=0"
+       src="#[myPreviewProtocol]#://#[myPreviewAddress]#/yacysearch.html?display=2&amp;resource=local&amp;focus=0"
        width="100%"
        height="180"
        frameborder="0"
@@ -193,7 +193,7 @@
     </pre></fieldset>
     This would look like:
     <iframe name="target3"
-       src="http://#[myPreviewAddress]#/yacyinteractive.html?display=2&amp;focus=0"
+       src="#[myPreviewProtocol]#://#[myPreviewAddress]#/yacyinteractive.html?display=2&amp;focus=0"
        width="100%"
        height="180"
        frameborder="0"

--- a/htroot/compare_yacy.java
+++ b/htroot/compare_yacy.java
@@ -43,19 +43,19 @@ public class compare_yacy {
         searchengines.put("YaCy (local)", "yacysearch.html?display=2&resource=local&query=");
         //searchengines.put("google.com", "https://www.google.com/#q=");
         searchengines.put("startpage.com", "https://startpage.com/do/search?cat=web&query=");
-        searchengines.put("bing.com", "http://www.bing.com/search?q=");
-        searchengines.put("metager.de", "http://www.metager.de/meta/cgi-bin/meta.ger1?eingabe=");
-        searchengines.put("metager2.de (web)", "http://www.metager2.de/search.php?ses=web&q=");
-        searchengines.put("metager2.de (international)", "http://www.metager2.de/search.php?ses=international&q=");
-        searchengines.put("yahoo.com", "http://search.yahoo.com/search?p=");
-        //searchengines.put("romso.de", "http://romso.de/?q="); // no serach service 2016-01-02
-        searchengines.put("Wikipedia English", "http://en.wikipedia.org/wiki/");
-        searchengines.put("Wikipedia Deutsch", "http://de.wikipedia.org/wiki/");
-        searchengines.put("Sciencenet", "http://sciencenet.fzk.de:8080/yacysearch.html?verify=true&resource=global&nav=all&display=2&meanCount=5&query=");
+        searchengines.put("bing.com", "https://www.bing.com/search?q=");
+        searchengines.put("metager.de", "https://www.metager.de/meta/cgi-bin/meta.ger1?eingabe=");
+        searchengines.put("metager2.de (web)", "https://www.metager2.de/search.php?ses=web&q=");
+        searchengines.put("metager2.de (international)", "https://www.metager2.de/search.php?ses=international&q=");
+        //searchengines.put("yahoo.com", "https://search.yahoo.com/search?p="); // no search service in iframe 2016-08-17 : "Load denied by X-Frame-Options: does not permit cross-origin framing."
+        //searchengines.put("romso.de", "http://romso.de/?q="); // no search service 2016-01-02
+        searchengines.put("Wikipedia English", "https://en.wikipedia.org/wiki/");
+        searchengines.put("Wikipedia Deutsch", "https://de.wikipedia.org/wiki/");
+        //searchengines.put("Sciencenet", "http://sciencenet.fzk.de:8080/yacysearch.html?verify=true&resource=global&nav=all&display=2&meanCount=5&query="); // no search service 2016-08-17
         //searchengines.put("dbpedia", "http://dbpedia.neofonie.de/browse/~:"); // no search service 2016-01-02
-        searchengines.put("wolfram alpha", "http://www.wolframalpha.com/input/?i=");
-        searchengines.put("OAIster@OCLC", "http://oaister.worldcat.org/search?q=");
-        searchengines.put("oai.yacy.net", "http://oai.yacy.net/yacysearch.html?verify=true&resource=local&nav=all&display=2&meanCount=5&query=");
+        searchengines.put("wolfram alpha", "https://www.wolframalpha.com/input/?i=");
+        searchengines.put("OAIster@OCLC", "https://oaister.worldcat.org/search?q=");
+        //searchengines.put("oai.yacy.net", "http://oai.yacy.net/yacysearch.html?verify=true&resource=local&nav=all&display=2&meanCount=5&query="); // no search service 2016-08-17
     }
 
     public static serverObjects respond(final RequestHeader header, final serverObjects post, final serverSwitch env) {

--- a/source/net/yacy/yacy.java
+++ b/source/net/yacy/yacy.java
@@ -39,13 +39,22 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.util.Properties;
 import java.util.concurrent.Semaphore;
+
+import com.google.common.io.Files;
+
 import net.yacy.cora.date.GenericFormatter;
+import net.yacy.cora.document.id.DigestURL;
+import net.yacy.cora.federate.yacy.CacheStrategy;
+import net.yacy.cora.order.Digest;
 import net.yacy.cora.protocol.ClientIdentification;
+import net.yacy.cora.protocol.ConnectionInfo;
 import net.yacy.cora.protocol.RequestHeader;
 import net.yacy.cora.protocol.TimeoutRequest;
 import net.yacy.cora.protocol.http.HTTPClient;
 import net.yacy.cora.sorting.Array;
 import net.yacy.cora.util.ConcurrentLog;
+import net.yacy.crawler.retrieval.Response;
+import net.yacy.document.Document;
 import net.yacy.gui.YaCyApp;
 import net.yacy.gui.framework.Browser;
 import net.yacy.http.Jetty9HttpServerImpl;
@@ -54,17 +63,11 @@ import net.yacy.kelondro.util.FileUtils;
 import net.yacy.kelondro.util.Formatter;
 import net.yacy.kelondro.util.MemoryControl;
 import net.yacy.kelondro.util.OS;
+import net.yacy.peers.Seed;
 import net.yacy.peers.operation.yacyBuildProperties;
 import net.yacy.peers.operation.yacyRelease;
 import net.yacy.search.Switchboard;
 import net.yacy.search.SwitchboardConstants;
-import com.google.common.io.Files;
-import net.yacy.cora.document.id.DigestURL;
-import net.yacy.cora.federate.yacy.CacheStrategy;
-import net.yacy.cora.order.Digest;
-import net.yacy.cora.protocol.ConnectionInfo;
-import net.yacy.crawler.retrieval.Response;
-import net.yacy.peers.Seed;
 import net.yacy.server.serverSwitch;
 import net.yacy.utils.translation.TranslatorXliff;
 
@@ -265,22 +268,7 @@ public final class yacy {
             //final File htTemplatePath = new File(homePath, sb.getConfig("htTemplatePath","htdocs"));
 
             // copy the donate iframe (better to copy this once here instead of doing this in an actual iframe in the search result)
-            final File wwwEnvPath = new File(htDocsPath, "env");
-            mkdirIfNeseccary(wwwEnvPath);
-            final String iframesource = sb.getConfig("donation.iframesource", "");
-            final String iframetarget = sb.getConfig("donation.iframetarget", "");
-            final File iframefile = new File(htDocsPath, iframetarget);
-            if (!iframefile.exists()) new Thread() {
-                @Override
-                public void run() {
-                    final ClientIdentification.Agent agent = ClientIdentification.getAgent(ClientIdentification.yacyInternetCrawlerAgentName);
-                    Response response;
-                    try {
-                        response = sb.loader == null ? null : sb.loader.load(sb.loader.request(new DigestURL(iframesource), false, true), CacheStrategy.NOCACHE, Integer.MAX_VALUE, null, agent);
-                        if (response != null) FileUtils.copy(response.getContent(), iframefile);
-                    } catch (Throwable e) {}
-                }
-            }.start();
+            importDonationIFrame(sb, htDocsPath);
             
             // create default notifier picture
             File notifierFile = new File(htDocsPath, "notifier.gif");
@@ -420,6 +408,59 @@ public final class yacy {
             System.exit(0);
         } catch (final Exception e) {} // was once stopped by de.anomic.net.ftpc$sm.checkExit(ftpc.java:1790)
     }
+
+    /**
+     * Concurrently import the donation iframe content to serve it directly from this peer.
+     * @param switchBoard the SwitchBoard instance. Must not be null.
+     * @param htDocsDirectory the custom htdocs directory. Must not be null.
+     */
+	private static void importDonationIFrame(final Switchboard switchBoard, final File htDocsDirectory) {
+		final File wwwEnvPath = new File(htDocsDirectory, "env");
+		mkdirIfNeseccary(wwwEnvPath);
+		final String iframesource = switchBoard.getConfig("donation.iframesource", "");
+		final String iframetarget = switchBoard.getConfig("donation.iframetarget", "");
+		final File iframefile = new File(htDocsDirectory, iframetarget);
+		if (!iframefile.exists()) new Thread() {
+		    @Override
+		    public void run() {
+		        final ClientIdentification.Agent agent = ClientIdentification.getAgent(ClientIdentification.yacyInternetCrawlerAgentName);
+		        Response documentResponse;
+		        try {
+		        	/* Load the donation html frame content */
+		        	documentResponse = switchBoard.loader == null ? null : switchBoard.loader.load(switchBoard.loader.request(new DigestURL(iframesource), false, true), CacheStrategy.NOCACHE, Integer.MAX_VALUE, null, agent);
+		            if (documentResponse != null) {
+		            	Document[] documents = documentResponse.parse();
+		            	if(documents != null && documents.length > 0 && documents[0] != null) {
+		            		Document donateDocument = documents[0];
+		            		String donateDocContent = new String(documentResponse.getContent(), donateDocument.getCharset());
+		            		/* Load image resources contained in the page */
+		            		if(donateDocument.getImages() != null) {
+		            			for(DigestURL imgURL : donateDocument.getImages().keySet()) {
+		            				try {
+		            					Response response = switchBoard.loader.load(switchBoard.loader.request(imgURL, false, true), CacheStrategy.NOCACHE, Integer.MAX_VALUE, null, agent);
+		            					if (response != null) {
+		            						String imgFileName = imgURL.getFileName();
+		            						/* Store each image in the same directory as the iframe target file */
+		            						FileUtils.copy(response.getContent(), new File(iframefile.getParentFile(), imgFileName));
+		                        	
+		            						/* Transform the original image URL to a relative one */
+		            						donateDocContent = donateDocContent.replace(imgURL.getURL().toString(), imgFileName);
+		            					}
+		            				} catch(IOException e) {
+		            					/* Failing to load one image should not stop the whole task */
+		            					ConcurrentLog.warn("STARTUP", "Donation frame retrieval : could not get an image resource.", e);
+		            				}
+		            			}
+		            		}
+			            	FileUtils.copy(donateDocContent.getBytes(donateDocument.getCharset()), iframefile);
+		            	}
+		            }
+		        } catch (Exception e) {
+		        	ConcurrentLog.warn("STARTUP", "Could not retrieve donation frame content.", e);
+		        }
+		    }
+		}.start();
+	}
 
 	/**
 	 * @param f


### PR DESCRIPTION
This is a fix for the issue described in mantis 680 (http://mantis.tokeek.de/view.php?id=680). Browsers warn and even block some contents when using HTTPS with the YaCy web interface.

Fix applied as described in mantis additional information.

Test configuration :
- YaCy peer : Linux Debian Jessie
- local browsing : Firefox 45.3.0
- remote browsing : Firefox 48.0 and Chrome 52.0.2743 on Windows 10 