### PR TITLE
YaCy Mac OS bundle : store data in the right place

### DIFF
--- a/addon/YaCy.app/Contents/Info.plist
+++ b/addon/YaCy.app/Contents/Info.plist
@@ -19,7 +19,7 @@
 <key>CFBundleAllowMixedLocalizations</key>
 <string>true</string>
 <key>CFBundleExecutable</key>
-<string>startYACY.sh</string>
+<string>startYACYMacOS.sh</string>
 <key>CFBundleDevelopmentRegion</key>
 <string>English</string>
 <key>CFBundlePackageType</key>

--- a/addon/YaCy.app/Contents/MacOS/startYACYMacOS.sh
+++ b/addon/YaCy.app/Contents/MacOS/startYACYMacOS.sh
@@ -5,4 +5,4 @@
 # This data directory is set in conforming to OS X File System Programming Guide 
 # see : https://developer.apple.com/library/ios/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/MacOSXDirectories/MacOSXDirectories.html
 
-"`dirname $0`"/startYACY.sh -startup "'Library/Application Support/net.yacy.YaCy'"
+"`dirname $0`"/startYACY.sh -s "'Library/Application Support/net.yacy.YaCy'"

--- a/addon/YaCy.app/Contents/MacOS/startYACYMacOS.sh
+++ b/addon/YaCy.app/Contents/MacOS/startYACYMacOS.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+# Launcher for YaCy in a MacOS bundle : 
+# rely on the generic startYACY.sh, but specifies the user home relative path for YaCy data
+# This data directory is set in conforming to OS X File System Programming Guide 
+# see : https://developer.apple.com/library/ios/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/MacOSXDirectories/MacOSXDirectories.html
+
+"`dirname $0`"/startYACY.sh -startup "'Library/Application Support/net.yacy.YaCy'"

--- a/build.xml
+++ b/build.xml
@@ -764,7 +764,8 @@
   	</copy>
   	<copy file="${addon}/YaCy.app/Contents/Info.plist" tofile="${release_mac}/YaCy.app/Contents/Info.plist" filtering="true" overwrite="true" />
   	<move file="${release_main}" tofile="${release_mac}/YaCy.app/Contents/MacOS" verbose="false" />
-  	<!-- startYACY.sh will be the main entry point : we set permissions to make it an executable file -->
+  	<!-- startYACY.sh and startYACYMacOS.sh will be the main entry points : we set permissions to make it executable files -->
+  	<chmod file="${release_mac}/YaCy.app/Contents/MacOS/startYACYMacOS.sh" perm="755"/>
   	<chmod file="${release_mac}/YaCy.app/Contents/MacOS/startYACY.sh" perm="755"/>
   	<exec executable="hdiutil">
   	  	<arg line="create -srcfolder ${release_mac}/YaCy.app ${release}/yacy_v${releaseVersion}_${DSTAMP}_${releaseNr}.dmg"/>

--- a/source/net/yacy/server/serverClassLoader.java
+++ b/source/net/yacy/server/serverClassLoader.java
@@ -64,7 +64,7 @@ public final class serverClassLoader extends ClassLoader {
     @Override
     protected Class<?> findClass(String classname) throws ClassNotFoundException {
         // construct path to htroot for a servletname
-        File cpath = new File (Switchboard.getSwitchboard().getDataPath(SwitchboardConstants.HTROOT_PATH, SwitchboardConstants.HTROOT_PATH_DEFAULT),classname+".class");
+        File cpath = new File (Switchboard.getSwitchboard().getAppPath(SwitchboardConstants.HTROOT_PATH, SwitchboardConstants.HTROOT_PATH_DEFAULT),classname+".class");
         return loadClass(cpath);
     }
 

--- a/source/net/yacy/yacy.java
+++ b/source/net/yacy/yacy.java
@@ -713,13 +713,17 @@ public final class yacy {
 	        //System.out.print("args=["); for (int i = 0; i < args.length; i++) System.out.print(args[i] + ", "); System.out.println("]");
 	        if ((args.length >= 1) && (args[0].toLowerCase().equals("-startup") || args[0].equals("-start"))) {
 	            // normal start-up of yacy
-	            if (args.length > 1) dataRoot = new File(System.getProperty("user.home").replace('\\', '/'), args[1]);
-                    preReadSavedConfigandInit(dataRoot);
+	            if (args.length > 1) {
+	            	dataRoot = new File(System.getProperty("user.home").replace('\\', '/'), args[1]);
+	            }
+                preReadSavedConfigandInit(dataRoot);
 	            startup(dataRoot, applicationRoot, startupMemFree, startupMemTotal, false);
 	        } else if (args.length >= 1 && args[0].toLowerCase().equals("-gui")) {
 	            // start-up of yacy with gui
-	            if (args.length > 1) dataRoot = new File(System.getProperty("user.home").replace('\\', '/'), args[1]);
-                    preReadSavedConfigandInit(dataRoot);
+	            if (args.length > 1) {
+	            	dataRoot = new File(System.getProperty("user.home").replace('\\', '/'), args[1]);
+	            }
+                preReadSavedConfigandInit(dataRoot);
 	            startup(dataRoot, applicationRoot, startupMemFree, startupMemTotal, true);
 	        } else if ((args.length >= 1) && ((args[0].toLowerCase().equals("-shutdown")) || (args[0].equals("-stop")))) {
 	            // normal shutdown of yacy
@@ -732,7 +736,7 @@ public final class yacy {
 	        } else if ((args.length >= 1) && (args[0].toLowerCase().equals("-version"))) {
 	            // show yacy version
 	            System.out.println(copyright);
-                } else if ((args.length > 1) && (args[0].toLowerCase().equals("-config"))) {
+            } else if ((args.length > 1) && (args[0].toLowerCase().equals("-config"))) {
                     // set config parameter. Special handling of adminAccount=user:pwd (generates md5 encoded password)
                     // on Windows parameter should be enclosed in doublequotes to accept = sign (e.g. -config "port=8090" "port.ssl=8043")
                     File f = new File (dataRoot,"DATA/SETTINGS/");
@@ -778,9 +782,11 @@ public final class yacy {
                         }
                         System.out.println();
                     }
-                } else {
-	            if (args.length == 1) applicationRoot= new File(args[0]);
-                    preReadSavedConfigandInit(dataRoot);
+            } else {
+	            if (args.length == 1) {
+	            	applicationRoot= new File(args[0]);
+	            }
+                preReadSavedConfigandInit(dataRoot);
 	            startup(dataRoot, applicationRoot, startupMemFree, startupMemTotal, false);
 	        }
     	} finally {

--- a/startYACY.sh
+++ b/startYACY.sh
@@ -40,7 +40,7 @@ Options
   -l, --logging		save the output of YaCy to yacy.log
   -d, --debug		show the output of YaCy on the console
   -p, --print-out	only print the command, which would be executed to start YaCy
-  -start, -startup [data-path] start YaCy using the specified data folder path, relative to the current user home
+  --start, --startup [data-path] start YaCy using the specified data folder path, relative to the current user home
   -g, --gui		start a gui for YaCy
 USAGE
 }
@@ -57,7 +57,7 @@ then
 		
         options="`getopt hdlptg: $*`"
 else
-        options="`getopt -n YaCy -o h,d,l,p,t,g -l help,debug,logging,print-out,tail-log,gui -- $@`"
+        options="`getopt -n YaCy -o h,d,l,p,t,g -l help,debug,logging,print-out,tail-log,gui,start,startup -- $@`"
 fi
 
 if [ $? -ne 0 ];then
@@ -72,6 +72,7 @@ LOGGING=0
 DEBUG=0
 PRINTONLY=0
 TAILLOG=0
+STARTUP=0
 GUI=0
 for option in $options;do
 	if [ $isparameter -ne 1 ];then #option
@@ -202,8 +203,7 @@ cmdline="$JAVA $JAVA_ARGS -classpath $CLASSPATH net.yacy.yacy";
 if [ $STARTUP -eq 1 ] #startup
 then
 	cmdline="$cmdline -startup $parameter"
-elif [ $GUI -eq 1 ] #gui
-then
+elif [ $GUI -eq 1 ];then #gui
 	cmdline="$cmdline -gui $parameter"
 fi
 if [ $DEBUG -eq 1 ] #debug

--- a/startYACY.sh
+++ b/startYACY.sh
@@ -40,6 +40,7 @@ Options
   -l, --logging		save the output of YaCy to yacy.log
   -d, --debug		show the output of YaCy on the console
   -p, --print-out	only print the command, which would be executed to start YaCy
+  -start, -startup [data-path] start YaCy using the specified data folder path, relative to the current user home
   -g, --gui		start a gui for YaCy
 USAGE
 }
@@ -101,6 +102,10 @@ for option in $options;do
 			-t|--tail-log)
 				TAILLOG=1
 				;;
+			-start|-startup)
+				STARTUP=1
+				isparameter=1
+				;;
 			-g|--gui)
 				GUI=1
 				isparameter=1
@@ -111,7 +116,11 @@ for option in $options;do
 			isparameter=1;
 			continue
 		else
-			parameter="$parameter $option"
+			if [ $parameter ];then
+				parameter="$parameter $option"
+			else
+				parameter="$option"
+			fi
 		fi
 	fi #parameter or option?
 done
@@ -189,7 +198,11 @@ for N in lib/*.jar; do CLASSPATH="$CLASSPATH$N:"; done
 CLASSPATH=".:$CLASSPATH"
 
 cmdline="$JAVA $JAVA_ARGS -classpath $CLASSPATH net.yacy.yacy";
-if [ $GUI -eq 1 ] #gui
+
+if [ $STARTUP -eq 1 ] #startup
+then
+	cmdline="$cmdline -startup $parameter"
+elif [ $GUI -eq 1 ] #gui
 then
 	cmdline="$cmdline -gui $parameter"
 fi

--- a/startYACY.sh
+++ b/startYACY.sh
@@ -40,7 +40,7 @@ Options
   -l, --logging		save the output of YaCy to yacy.log
   -d, --debug		show the output of YaCy on the console
   -p, --print-out	only print the command, which would be executed to start YaCy
-  --start, --startup [data-path] start YaCy using the specified data folder path, relative to the current user home
+  -s, --startup [data-path] start YaCy using the specified data folder path, relative to the current user home
   -g, --gui		start a gui for YaCy
 USAGE
 }
@@ -48,16 +48,16 @@ USAGE
 #startup YaCy
 cd "`dirname $0`"
 
-if [ $OS = "OpenBSD" ]
+if [ $OS = "OpenBSD" ] || [ $OS = "Darwin" ]
 then
 		if [ $(echo $@ | grep -o "\-\-" | wc -l) -ne 0  ]
 		then
 			echo "WARNING: Unfortunately this script does not support long options in $OS."
 		fi
 		
-        options="`getopt hdlptg: $*`"
+        options="`getopt hdlptsg: $*`"
 else
-        options="`getopt -n YaCy -o h,d,l,p,t,g -l help,debug,logging,print-out,tail-log,gui,start,startup -- $@`"
+        options="`getopt -n YaCy -o h,d,l,p,t,s,g -l help,debug,logging,print-out,tail-log,startup,gui -- $@`"
 fi
 
 if [ $? -ne 0 ];then
@@ -103,7 +103,7 @@ for option in $options;do
 			-t|--tail-log)
 				TAILLOG=1
 				;;
-			-start|-startup)
+			-s|-startup)
 				STARTUP=1
 				isparameter=1
 				;;
@@ -113,7 +113,7 @@ for option in $options;do
 				;;
 		esac #case option 
 	else #parameter
-		if [ x$option = "--" ];then #option / parameter separator
+		if [ $option = "--" ];then #option / parameter separator
 			isparameter=1;
 			continue
 		else


### PR DESCRIPTION
I modified the YaCy Mac OS bundle to store DATA in ~/Library/Application Support/net.yacy.YaCy, thus conforming to the official OS X bundle programming guide :
- created a startYACYMacoOS.sh specific launcher script
- modified startYACY.sh : added a -s/--startup option, allowing to pass data folder to the existing 'startup' option in main net.yacy.yacy
- fixed startYACY.sh MAC OS specific getopt processing
- fixed serverClassLoader.findClass : wrong loading path was making CrawlStartSite.html and Performance_p.html servlet crash when loading from the MacOs bundle

Running YACY from a read-only dmg image is now working.

Tested non-regression for startYACY.sh on Linux Debian Jessie.