### PR TITLE
(WIP) Tradeoff between sorting accuracy and display latency

### DIFF
--- a/source/net/yacy/search/query/SearchEvent.java
+++ b/source/net/yacy/search/query/SearchEvent.java
@@ -1591,10 +1591,18 @@ public final class SearchEvent {
         }
         
         // now pull results as long as needed and as long as possible
-        if (this.remote && item < 10 && this.resultList.sizeAvailable() <= item) try {Thread.sleep(100);} catch (final InterruptedException e) {ConcurrentLog.logException(e);}
-        while ( this.resultList.sizeAvailable() <= item &&
+        //if (this.remote && item < 10 && this.resultList.sizeAvailable() <= item) try {Thread.sleep(100);} catch (final InterruptedException e) {ConcurrentLog.logException(e);}
+        if (this.remote && item == 0) try {Thread.sleep(2000);} catch (final InterruptedException e) {ConcurrentLog.logException(e);}
+        // this.rwiQueueSize() > 0                 : always wait
+        // this.nodeStack.sizeQueue() > 0          : always wait
+        // this.resultList.sizeAvailable() <= item : wait if (!this.feedingIsFinished() && System.currentTimeMillis() < finishTime)
+        while ( this.rwiQueueSize() > 0 || this.nodeStack.sizeQueue() > 0 || 
+                ( this.resultList.sizeAvailable() <= item && !this.feedingIsFinished() && System.currentTimeMillis() < finishTime ) ) {
+        /*
+        while ( this.resultList.sizeAvailable() <= item ||
                 (this.rwiQueueSize() > 0 || this.nodeStack.sizeQueue() > 0 ||
                 (!this.feedingIsFinished() && System.currentTimeMillis() < finishTime))) {
+        */
             if (!drainStacksToResult()) try {Thread.sleep(10);} catch (final InterruptedException e) {ConcurrentLog.logException(e);}
         }
         

--- a/source/net/yacy/search/query/SearchEvent.java
+++ b/source/net/yacy/search/query/SearchEvent.java
@@ -1592,7 +1592,7 @@ public final class SearchEvent {
         
         // now pull results as long as needed and as long as possible
         //if (this.remote && item < 10 && this.resultList.sizeAvailable() <= item) try {Thread.sleep(100);} catch (final InterruptedException e) {ConcurrentLog.logException(e);}
-        if (this.remote && item == 0) try {Thread.sleep(2000);} catch (final InterruptedException e) {ConcurrentLog.logException(e);}
+        if (this.remote && item == 0) try {Thread.sleep(5000);} catch (final InterruptedException e) {ConcurrentLog.logException(e);}
         // this.rwiQueueSize() > 0                 : always wait
         // this.nodeStack.sizeQueue() > 0          : always wait
         // this.resultList.sizeAvailable() <= item : wait if (!this.feedingIsFinished() && System.currentTimeMillis() < finishTime)


### PR DESCRIPTION
(Don't merge this PR, it's an experiment.)

At the moment, from what I can tell, YaCy waits a very short period of time, then drains exactly 1 result from the Solr and RWI queues into the output queue, and then checks whether the output queue has at least 1 result in it that hasn't yet been displayed to the user.  Naturally, this is true 100% of the time.  When YaCy sees this, it writes the best result in its output queue (i.e. either the single Solr result or the single RWI result) to the user.  It then repeats.  (See the section of code modified by this PR to see what code I'm talking about.)

The effect is that there is almost no correlation between the ordering of the results displayed to the user and the ranking calculated by YaCy; the dominant factor is which results got returned first by a peer.  Kind of useless as a sorting mechanism.

The easy hack to fix this is to add a significant delay right before the above algorithm runs, which gives the Solr and RWI queues enough time to receive a lot of results before they start being drained into the output queue.  The example code in this PR is a hacky way of doing this.

However, the problem is that it adds a long delay before the end user sees any results at all, and there is a tradeoff between the delay and the sorting quality.

My suggestions for a better way to implement a fix than this PR:

1. For API-based use cases that retrieve a single list, e.g. the XML and JSON output formats, provide a way for the user to choose how long to wait for results before the queues start being drained (probably an HTTP GET parameter is reasonable for this).  My guess is that 5 to 10 seconds is going to be enough time for an API user on a fast residential Internet connection (or at least, the first 100 results are likely to be properly sorted in such cases).  Users on Tor are likely to need more time.
2. For human-user use cases where Javascript is available, load each result via AJAX and use Javascript to insert it in the correct order.  Don't stop receiving results over AJAX when the result limit is hit; keep receiving them for approximately 1 minute.  Hide the least relevant results via Javascript once more results have been received over AJAX than the result limit.
3. For API-based use cases where the user is willing to call the API multiple times, re-sort the result list each time the API is called, so that the user gets more relevant results after waiting but they get some possibly-relevant results quickly.  Probably one way to do this with minimal code changes is to create a new queue, drain the entire output queue into the new queue, and then replace the output queue with the new queue.

If these suggestions are okay with you, I'm willing to try my hand at implementing them.  Or, if you have a better suggestion for how this should be handled, please feel free to let me know.