### PR TITLE
Allow disabling Javabin encoding for remote Solr queries.

### DIFF
--- a/defaults/yacy.init
+++ b/defaults/yacy.init
@@ -1217,6 +1217,7 @@ federated.service.solr.indexing.sharding = MODULO_HOST_MD5
 federated.service.solr.indexing.lazy = true
 federated.service.solr.indexing.timeout = 60000
 federated.service.solr.indexing.writeEnabled = true
+federated.service.solr.indexing.binaryResponseEnabled = true
 
 # temporary definition of backend services to use.
 # After the migration a rwi+solr combination is used, the solr contains the content of the previously used metadata-db.

--- a/source/net/yacy/cora/federate/solr/connector/RemoteSolrConnector.java
+++ b/source/net/yacy/cora/federate/solr/connector/RemoteSolrConnector.java
@@ -27,6 +27,8 @@ import java.util.ArrayList;
 import net.yacy.cora.federate.solr.instance.SolrInstance;
 import net.yacy.cora.federate.solr.instance.RemoteInstance;
 import net.yacy.cora.federate.solr.instance.ShardInstance;
+import net.yacy.search.Switchboard;
+import net.yacy.search.SwitchboardConstants;
 
 import org.apache.solr.client.solrj.ResponseParser;
 import org.apache.solr.client.solrj.SolrClient;
@@ -52,7 +54,7 @@ public class RemoteSolrConnector extends SolrServerConnector implements SolrConn
     public RemoteSolrConnector(final SolrInstance instance, final boolean useBinaryResponseWriter) throws IOException {
         super();
         this.instance = instance;
-        this.useBinaryResponseWriter = useBinaryResponseWriter;
+        this.useBinaryResponseWriter = useBinaryResponseWriter && Switchboard.getSwitchboard().getConfigBool(SwitchboardConstants.FEDERATED_SERVICE_SOLR_INDEXING_BINARYRESPONSEENABLED, true);
         this.corename = this.instance.getDefaultCoreName();
         SolrClient s = instance.getServer(this.corename);
         super.init(s);
@@ -61,7 +63,7 @@ public class RemoteSolrConnector extends SolrServerConnector implements SolrConn
     public RemoteSolrConnector(final SolrInstance instance, final boolean useBinaryResponseWriter, String corename) {
         super();
         this.instance = instance;
-        this.useBinaryResponseWriter = useBinaryResponseWriter;
+        this.useBinaryResponseWriter = useBinaryResponseWriter && Switchboard.getSwitchboard().getConfigBool(SwitchboardConstants.FEDERATED_SERVICE_SOLR_INDEXING_BINARYRESPONSEENABLED, true);
         this.corename = corename == null ? this.instance.getDefaultCoreName() : corename;
         SolrClient s = instance.getServer(this.corename);
         super.init(s);

--- a/source/net/yacy/search/SwitchboardConstants.java
+++ b/source/net/yacy/search/SwitchboardConstants.java
@@ -302,6 +302,7 @@ public final class SwitchboardConstants {
     public static final String FEDERATED_SERVICE_SOLR_INDEXING_LAZY         = "federated.service.solr.indexing.lazy";
     public static final String FEDERATED_SERVICE_SOLR_INDEXING_TIMEOUT      = "federated.service.solr.indexing.timeout";
     public static final String FEDERATED_SERVICE_SOLR_INDEXING_WRITEENABLED = "federated.service.solr.indexing.writeEnabled";
+    public static final String FEDERATED_SERVICE_SOLR_INDEXING_BINARYRESPONSEENABLED = "federated.service.solr.indexing.binaryResponseEnabled";
 
     public static final String CORE_SERVICE_FULLTEXT            = "core.service.fulltext";
     public static final String CORE_SERVICE_RWI                 = "core.service.rwi.tmp";


### PR DESCRIPTION
YaCy configures Solr to return results in Javabin encoding rather than XML.  This is good from an efficiency standpoint, because Javabin is much more compact than XML.  However, Javabin only has an implementation in Java, whereas almost anything can process XML.  This is problematic, since as a Free Software program, YaCy should try to interoperate with other software as much as possible rather than locking users into Javabin.  In practice, this caused me a significant amount of frustration when I was trying to do experiments with the debugging tool mitmproxy, which (as a Python program) can't parse or serialize Javabin.

This PR adds an optional setting for enabling Javabin.  It defaults to true (meaning that the current behavior is preserved), but if it is explicitly set to false, YaCy will ask Solr to return results in XML (so that the protocol is interoperable with software that doesn't speak Javabin).

I wasn't sure where the best place would be to expose this option in the settings UI, so right now it's only accessible by changing the raw setting.  That's not really a good thing, since I doubt many users will notice the raw setting.  If anyone can offer suggestions where it would best fit, I will make that change before it's merged.

Cheers.