### PR TITLE
Added entrypoint script for docker to catch SIGTERM

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,5 +52,7 @@ VOLUME ["/opt/yacy_search_server/DATA"]
 # Next commands run as yacy as non-root user for improved security
 USER yacy
 
-# Start yacy in debug mode (-d) to display console logs and to wait for yacy process
-CMD sh /opt/yacy_search_server/startYACY.sh -d
+
+# Add and set entrypoint script to start and stop YaCy 
+ADD entrypoint.sh /bin/entrypoint.sh
+ENTRYPOINT ["/bin/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+trap "{ 
+echo Exit TRAP snapped
+
+/opt/yacy_search_server/stopYACY.sh
+
+exit 0
+
+}" SIGTERM
+
+/opt/yacy_search_server/startYACY.sh -d &
+
+wait


### PR DESCRIPTION
The startYaCy.sh script does not catch SIGTERM from `docker stop` so the instance is killed after the `docker stop` command times out. 

The entrypoint script invokes stopYaCy.sh when it receives a SIGTERM and shuts down YaCy in a clean fashion.

