### PR TITLE
adjusted .travis.yml to build in libbuild first and test build instructions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,16 @@ cache:
 jdk:
   - oraclejdk7
 
-# for running tests on Travis CI container infrastructure for faster builds
-sudo: false
+# only `sudo: true` allows running tests on Travis CI container infrastructure for faster builds, but testing installation of .deb makes sense
+sudo: true
+
+install:
+- cd libbuild && MAVEN_OPTS="-Xmx6g -Xms2g" mvn clean install && cd ..
+
+script:
+- MAVEN_OPTS="-Xmx6g -Xms2g" mvn clean install
+# test build instructions
+- ant
+- ant dist
+- ant deb
+- sudo dpkg -i *.deb


### PR DESCRIPTION
Currently, travis-ci.org is unused and the `.travis.yml` wouldn't work on it because it doesn't build in `libbuild` (see http://mantis.tokeek.de/view.php?id=545) first.

Furthermore it's nice to test the build instructions.

[There's a test failure due to Java heap space](https://travis-ci.org/krichter722/yacy_search_server/builds/212851999), but I can't evaluate whether this requires a fix of the unit test or of the travis script (6 GB is plenty, maybe it's not forwarded to the forked surefire JVM).