### PR TITLE
Wrong password was removed after the SSL certificate import

### DIFF
--- a/source/net/yacy/http/Jetty9HttpServerImpl.java
+++ b/source/net/yacy/http/Jetty9HttpServerImpl.java
@@ -423,7 +423,7 @@ public class Jetty9HttpServerImpl implements YaCyHttpServer {
  
                 // removing entries from config file
                 sb.setConfig("pkcs12ImportFile", "");
-                sb.setConfig("keyStorePassword", "");
+                sb.setConfig("pkcs12ImportPwd", "");
  
                 // deleting original import file
                 // TODO: should we do this


### PR DESCRIPTION
Removing the keystore password will prevent ssl from working after the next restart. The certificate password should be removed instead.
Fixes http://mantis.tokeek.de/view.php?id=687