### PR TITLE
Fix AutoCommit & soft AutoCommit

### DIFF
--- a/defaults/solr/solrconfig.xml
+++ b/defaults/solr/solrconfig.xml
@@ -314,7 +314,7 @@
          have some sort of hard autoCommit to limit the log size.
       -->
      <autoCommit> 
-       <maxTime>${solr.autoCommit.maxTime:15000}</maxTime> 
+       <maxTime>15000</maxTime> 
        <openSearcher>false</openSearcher> 
      </autoCommit>
 
@@ -325,7 +325,7 @@
       -->
 
      <autoSoftCommit> 
-       <maxTime>${solr.autoSoftCommit.maxTime:-1}</maxTime> 
+       <maxTime>1000</maxTime> 
      </autoSoftCommit>
 
     <!-- Update Related Event Listeners


### PR DESCRIPTION
Current settings disabled both AutoCommit and soft AutoCommit with the currently used version of Solr.
This should ensure that YaCy always gets fresh index without needing to explicitly commit, as it is recommended not to do that by the official Sorl docs.