### PR TITLE
Add contributor guidelines; closes #214

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# YaCy contributor guidelines
+
+Thank you for contributing to YaCy!
+We appreciate all contributions, no matter how small.
+
+Please create a pull request.
+
+Some tips to make it more likely for your pull request to be accepted:
+
+- Don't make big changes without discussing it first.
+    - Don't make big refactorings without any new functionality.
+    - Don't remove functionality unless we discussed that somewhere.
+- Don't change whitespaces unnecessarily.
+    - Don't change line endings (LF/CRLF).
+    - Don't change formatting (spaces, tabs).
+- Don't commit code you don't understand.
+    - Don't commit code without testing its function (and a bit of debugging).
+- Don't put someone else's name in your copyright statement (don't put other people's name in the copyright statement if you add a new class; put your own name).


### PR DESCRIPTION
This is a sketch for #214.

This might not be the best contributor guide... Changes are welcome. Feel free to change or suggest changes.

Related:

- https://help.github.com/articles/setting-guidelines-for-repository-contributors/
    - GitHub will show a link to `CONTRIBUTING.md` whenever someone creates an issue or a pull request.

Thanks!