### PR TITLE
Fix English Bookmarks.html

### DIFF
--- a/htroot/Bookmarks.html
+++ b/htroot/Bookmarks.html
@@ -239,7 +239,7 @@ To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de
                     </table>
                     #(/autosearchrunning)#
                     <br />
-                    <p>This starts a serach of new or modified bookmarks since startup
+                    <p>This starts a search of new or modified bookmarks since startup
                         in folder "search" with "query=&lt;original_search_term&gt;"<br />
                         Every peer online will be ask for results.                        
                     </p>


### PR DESCRIPTION
Translating to Spanish I checked in the translator editor there is a string with a typo error. This PR fix the word ``serach`` to ``search``. I don't know if it is necessary to make more changes to solve it, but if there are more necessary changes, tell me and I will try to make it.

Regards,
Iván