### PR TITLE
Increase timeout of IndexBrowser_p operations to 5 minutes

### DIFF
--- a/htroot/IndexBrowser_p.java
+++ b/htroot/IndexBrowser_p.java
@@ -73,7 +73,7 @@ import net.yacy.server.serverSwitch;
  */
 public class IndexBrowser_p {
 
-    final static long TIMEOUT = 10000L;
+    final static long TIMEOUT = 5 * 60000L;
 
     public static enum StoreType {
         LINK, INDEX, EXCLUDED, FAILED, RELOAD;
@@ -403,7 +403,7 @@ public class IndexBrowser_p {
                 final Set<String> reloadURLCollection = new HashSet<String>();
                 long timeoutList = System.currentTimeMillis() + TIMEOUT;
                 long remainingTime = TIMEOUT;
-                long timeoutReferences = System.currentTimeMillis() + 6000;
+                long timeoutReferences = System.currentTimeMillis() + TIMEOUT;
                 ReferenceReportCache rrCache = sb.index.getReferenceReportCache();
                 try {
                     SolrDocument doc = docs.poll(remainingTime, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
On hosts with large number of documents, display of subpaths or reload404 get timeout before they manage to complete, thus it might display an empty subpath or reload404 does not work properly.

I increased it to 5 minutes. I think that it's better to have a large timeout limit than not working at all without showing any timeout error. Even better, such kind of timeouts can be in configuration.

Any better ideas are welcome.