### PR TITLE
fix ant build failure on multiple call to resolve target

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -103,7 +103,7 @@
     <taskdef resource="org/apache/ivy/ant/antlib.xml" uri="antlib:org.apache.ivy.ant" classpath="${ivy.jar.file}"/>
   </target>
 
-  <target name="resolve" depends="install-ivy" description="--> retrieve dependencies with Ivy">
+  <target name="resolve" depends="install-ivy" description="--> retrieve dependencies with Ivy" unless="target-resolve-already-run">
     <!-- The recommended way is to [conf] in the retrieve pattern instead of two calls to retrieve.
          We can move there in a following step.
          ${lib} just happens to be equal to ${ivy.lib.dir}.
@@ -111,6 +111,7 @@
     <ivy:retrieve conf="compile" pathid="compile.path" pattern="${ivy.lib.dir}/[artifact]-[revision].[ext]" />
     <ivy:retrieve conf="test" pathid="test.path" pattern="${libt}/[artifact]-[revision].[ext]" />
     <ivy:retrieve conf="libbuild" pathid="libbuild.path" pattern="${libbuild}/[artifact]-[revision].[ext]" />
+    <property name="target-resolve-already-run" value="true" />
   </target>
 
   <target name="buildGitRevTask" depends="resolve">


### PR DESCRIPTION
Failed build:
https://github.com/yacy/yacy_search_server/runs/6859314856

Relevant build log:

resolve:
[ivy:retrieve] ivy.instance reference an ivy:settings defined in an other classloader.  An new default one will be used in this project.
[ivy:retrieve] :: Apache Ivy non official version -  :: http://ant.apache.org/ivy/ ::
[ivy:retrieve] :: loading settings :: url = jar:file:/usr/share/java/ivy.jar!/org/apache/ivy/core/settings/ivysettings.xml
BUILD FAILED
/home/yacy/actions-runner/_work/yacy_search_server/yacy_search_server/build.xml:111:
 java.lang.ClassCastException: org.apache.ivy.core.module.descriptor.DefaultModuleDescriptor
 cannot be cast to org.apache.ivy.core.module.descriptor.ModuleDescriptor

Finding:

The second call to the resolve target in ant failed apparently due to
two instances of Ivy in the java runtime.
Without full investigation, the problem could be fixed by ensuring that
the resolve target is only called once within one ant build.