### PR TITLE
docker has no latest-alpine

### DIFF
--- a/docker/Readme.md
+++ b/docker/Readme.md
@@ -10,7 +10,6 @@
 The repository URL is https://hub.docker.com/r/yacy/yacy_search_server/
 
 * ubuntu-based: `docker pull yacy/yacy_search_server:latest`
-* alpine-based: `docker pull yacy/yacy_search_server:latest-alpine`
 
 
 ## Building image yourself


### PR DESCRIPTION
There is no yacy/yacy_search_server:latest-alpine  on docker hub