### PR TITLE
skip github jobs on forks

### DIFF
--- a/.github/workflows/ant-build-pull-request.yaml
+++ b/.github/workflows/ant-build-pull-request.yaml
@@ -5,6 +5,7 @@ on: pull_request
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: "github.repository == 'yacy/yacy_search_server'
     steps:
     - uses: actions/checkout@master
     - name: Set up JDK 8

--- a/.github/workflows/ant-build-selfhosted.yaml
+++ b/.github/workflows/ant-build-selfhosted.yaml
@@ -5,6 +5,7 @@ on: push
 jobs:
   build:
     runs-on: self-hosted
+    if: "github.repository == 'yacy/yacy_search_server'
     steps:
     - uses: actions/checkout@master
     - name: Set up JDK 8


### PR DESCRIPTION
I get scary emails from github about failed jobs for every commit pushed to my yacy fork. But the jobs should not run on my forked repo in the first place.

This problem is not unique to yacy:
https://github.com/actions/runner/issues/859

Alternatively every contributor could disable workflows in the settings of their fork repo:
https://docs.github.com/en/actions/managing-workflow-runs/disabling-and-enabling-a-workflow