### PR TITLE
Menu links

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The (GPLv2+) source code used to build YaCy is distributed with the package (in 
 
 - [Homepage](https://yacy.net)
 - [International Forum](https://community.searchlab.eu)
+- [Documentation / FAQ](https://yacy.net/faq/)
 - [English wiki](https://wiki.yacy.net/index.php/En:Start)
 - [German wiki](https://wiki.yacy.net/index.php/De:Start)
 - [Esperanto wiki](https://wiki.yacy.net/index.php/Eo:Start)
@@ -54,6 +55,7 @@ The (GPLv2+) source code used to build YaCy is distributed with the package (in 
 - [Spanish wiki](https://wiki.yacy.net/index.php/Es:Start)
 - [Russian wiki](https://wiki.yacy.net/index.php/Ru:Start)
 - [Video tutorials](https://www.youtube.com/@YaCyTutorials/videos)
+- [javadoc documentation](https://yacy.net/api/javadoc/) for developers
 
 All these have (YaCy) search functionality combining all these locations into one search result.
 
@@ -178,6 +180,14 @@ git clone https://github.com/yacy/yacy_search_server
 Compiling YaCy:
 - You need Java 1.8 and ant
 - See `ant -p` for the available ant targets
+```
+ant clean dist
+```
+resulting tar.gz with YaCy package will be located in RELEASE/ directory.
+Move it into desired location and unpack with:
+```
+tar zfvx yacy_v1.version_release_number_different_each_time.tar.gz
+``` 
 
 ## APIs and attaching software
 

--- a/htroot/env/templates/header.template
+++ b/htroot/env/templates/header.template
@@ -126,8 +126,10 @@
           <li id="header_profile"><a href="ViewProfile.html?hash=localhash">About This Page</a></li>
           <li id="header_jslicense"><a href="jslicense.html" data-jslicense="1">JavaScript information</a></li>
           <li class="divider" role="separator"></li>
+          <li id="header_faq"><a href="https://yacy.net/faq/" target="_blank"><i>external</i>&nbsp;&nbsp;&nbsp;Documentation / FAQ</a></li>
+          <li id="header_wiki"><a href="https://wiki.yacy.net/index.php/En:Start" target="_blank"><i>external</i>&nbsp;&nbsp;&nbsp;YaCy wiki (legacy)</a></li>
           <li id="header_tutorial"><a href="https://www.youtube.com/user/YaCyTutorials/videos" target="_blank"><i>external</i>&nbsp;&nbsp;&nbsp;YaCy Tutorials</a></li>
-          <li id="header_download"><a href="https://yacy.net" target="_blank"><i>external</i>&nbsp;&nbsp;&nbsp;Download YaCy</a></li>
+          <li id="header_download"><a href="https://yacy.net/download_installation/" target="_blank"><i>external</i>&nbsp;&nbsp;&nbsp;Download YaCy</a></li>
           <li id="header_community"><a href="https://community.searchlab.eu" target="_blank"><i>external</i>&nbsp;&nbsp;&nbsp;Community (Web Forums)</a></li>
           <li id="header_git"><a href="https://github.com/yacy/yacy_search_server" target="_blank"><i>external</i>&nbsp;&nbsp;&nbsp;Git Repository</a></li>
           </ul>


### PR DESCRIPTION
added a link to faq and legacy wiki to "help menu" as they were missing.
new documentation (FAQ) wasn't linked at all and wiki link is considered as a temporary help to users until everything is transfered to FAQ.