### PR TITLE
UI: modified link to Process Scheduler in left menu

### DIFF
--- a/htroot/env/templates/header.template
+++ b/htroot/env/templates/header.template
@@ -211,7 +211,7 @@
       <li><a href="IndexControlURLs_p.html" class="MenuItemLink #(authorized)#lock::unlock#(/authorized)#">Index Administration</a></li>
       <li><a href="Settings_p.html" class="MenuItemLink #(authorized)#lock::unlock#(/authorized)#">System Administration</a></li>
       <li><a href="Blacklist_p.html" class="MenuItemLink #(authorized)#lock::unlock#(/authorized)#">Filter &amp; Blacklists</a></li>
-      <li><a href="Table_API_p.html" class="MenuItemLink #(authorized)#lock::unlock#(/authorized)#">Process Scheduler</a></li>
+      <li><a href="Table_API_p.html?sort=-date_recording" class="MenuItemLink #(authorized)#lock::unlock#(/authorized)#">Process Scheduler</a></li>
     </ul>
     <ul class="nav nav-sidebar menugroup">
       <li><h3>Search Portal Integration</h3></li>


### PR DESCRIPTION
Typical use of Process Scheduler is recalling the recent action. After entering Process Scheduler from left menu, sorting by date ascending mode is entered, user sees the very first actions (such as initial setup) and has to click Recording date to reverse the order. 

To ease this action I changed the default sort mode of Process Scheduler linked from left menu to "-date_recorded". 