### PR TITLE
added some logging prefixes to yacy.logging

### DIFF
--- a/defaults/yacy.logging
+++ b/defaults/yacy.logging
@@ -22,10 +22,20 @@ CRAWLER.level = INFO
 STACKCRAWL.level = INFO
 MEMORY.level = INFO
 HTTPC.level = INFO
+
+# RWI related
 INDEX-TRANSFER-DISPATCHER.level = INFO
+SWITCHBOARD.level = INFO
+DHT.level = INFO
+INDEX-TRANSFER-DISPATCHER.level = INFO
+HeapReader.level = INFO
+Heap.level = INFO
+
+
 # UPnP related
 UPNP.level = INFO
 sun.net.www.protocol.http.HttpURLConnection.level = INFO
+
 # Tray
 sun.awt.level = OFF
 java.awt.level = OFF


### PR DESCRIPTION
I added some missing logging prefixes as an option into default yacy.logging file, so the user can fine-tune the logging.

Preparation for an effort to make the logfiles more usable, as described in #611.