### PR TITLE
Logging unclutter

### DIFF
--- a/defaults/yacy.logging
+++ b/defaults/yacy.logging
@@ -10,10 +10,13 @@
 # INFO    regular action information (i.e. any httpd request URL)
 # CONFIG  regular system status information (i.e. start-up messages)
 # FINE  in-function status debug output
+# FINER  more details in debug output
+# FINEST  even more details in debug output
 BASE64.level = OFF
 PARSER.level = INFO
 PROXY.level = INFO
 YACY.level = INFO
+NETWORK.level = INFO
 HTCACHE.level = INFO
 PLASMA.level = INFO
 SERVER.level = INFO

--- a/source/net/yacy/htroot/yacy/hello.java
+++ b/source/net/yacy/htroot/yacy/hello.java
@@ -207,7 +207,7 @@ public final class hello {
                 remoteSeed.put(Seed.PEERTYPE, Seed.PEERTYPE_SENIOR);
             }
             // connect the seed
-            Network.log.info("hello/server: responded remote " + reportedPeerType + " peer '" + remoteSeed.getName() + "' from " + reportedips + ", time_dnsResolve=" + time_dnsResolve + ", time_backping=" + time_backping + ", method=" + backping_method + ", urls=" + callback[0]);
+            Network.log.fine("hello/server: responded remote " + reportedPeerType + " peer '" + remoteSeed.getName() + "' from " + reportedips + ", time_dnsResolve=" + time_dnsResolve + ", time_backping=" + time_backping + ", method=" + backping_method + ", urls=" + callback[0]);
             sb.peers.peerActions.peerArrival(remoteSeed, true);
         } else {
             //ConcurrentLog.info("**hello-DEBUG**", "fail for IP(s) " + remoteSeed.getIPs() + ", port " + remoteSeed.getPort());
@@ -215,7 +215,7 @@ public final class hello {
             remoteSeed.setIP(ias.getHostAddress());
             prop.put(Seed.YOURTYPE, Seed.PEERTYPE_JUNIOR);
             remoteSeed.put(Seed.PEERTYPE, Seed.PEERTYPE_JUNIOR);
-            Network.log.info("hello/server: responded remote " + reportedPeerType + " peer '" + remoteSeed.getName() + "' from " + reportedips + ", time_dnsResolve=" + time_dnsResolve + ", time_backping=" + time_backping + ", method=" + backping_method + ", urls=" + callback[0]);
+            Network.log.fine("hello/server: responded remote " + reportedPeerType + " peer '" + remoteSeed.getName() + "' from " + reportedips + ", time_dnsResolve=" + time_dnsResolve + ", time_backping=" + time_backping + ", method=" + backping_method + ", urls=" + callback[0]);
             // no connection here, instead store junior in connection cache
             if ((remoteSeed.hash != null) && (remoteSeed.isProper(false) == null)) {
                 sb.peers.peerActions.peerPing(remoteSeed);
@@ -227,7 +227,7 @@ public final class hello {
         // update event tracker
         EventTracker.update(EventTracker.EClass.PEERPING, new ProfilingGraph.EventPing(remoteSeed.getName(), sb.peers.myName(), false, connectedAfter - connectedBefore), false);
         if (!(prop.get(Seed.YOURTYPE)).equals(reportedPeerType)) {
-            Network.log.info("hello/server: changing remote peer '" + remoteSeed.getName() + "' " + reportedips + " peerType from '" + reportedPeerType + "' to '" + prop.get(Seed.YOURTYPE) + "'.");
+            Network.log.fine("hello/server: changing remote peer '" + remoteSeed.getName() + "' " + reportedips + " peerType from '" + reportedPeerType + "' to '" + prop.get(Seed.YOURTYPE) + "'.");
         }
 
         final StringBuilder seeds = new StringBuilder(768);
@@ -268,7 +268,7 @@ public final class hello {
         prop.put("seedlist", seeds.toString());
         // return rewrite properties
         prop.put("message", "ok " + seed.length());
-        Network.log.info("hello/server: responded remote peer '" + remoteSeed.getName() + "' " + reportedips + " in " + (System.currentTimeMillis() - start) + " milliseconds");
+        Network.log.fine("hello/server: responded remote peer '" + remoteSeed.getName() + "' " + reportedips + " in " + (System.currentTimeMillis() - start) + " milliseconds");
         return prop;
     }
 

--- a/source/net/yacy/peers/DHTSelection.java
+++ b/source/net/yacy/peers/DHTSelection.java
@@ -215,7 +215,7 @@ public class DHTSelection {
             	/* Even if the peer is not a robinson and has the required minimum age, it may have an empty or disabled RWI */
             	continue;
             }
-            if (RemoteSearch.log.isInfo()) RemoteSearch.log.info("selectPeers/DHTorder: " + seed.hash + ":" + seed.getName() + "/ score " + c);
+            if (RemoteSearch.log.isFine()) RemoteSearch.log.fine("selectPeers/DHTorder: " + seed.hash + ":" + seed.getName() + "/ score " + c);
             seeds.add(seed);
             c--;
         }

--- a/source/net/yacy/peers/Dispatcher.java
+++ b/source/net/yacy/peers/Dispatcher.java
@@ -281,7 +281,7 @@ public class Dispatcher implements WorkflowTask<Transmission.Chunk> {
             for (Seed target: targets[vertical]) {
                 Transmission.Chunk entry = this.transmissionBuffer.get(target.hash); // if this is not null, the entry is extended here
                 if (entry == null) entry =  transmission.newChunk(target); else {
-                    log.info("extending chunk for peer " + entry.dhtTarget().hash + " containing " + entry.containersSize() + " references with " + verticalContainer.size() + " more entries");
+                    log.fine("extending chunk for peer " + entry.dhtTarget().hash + " containing " + entry.containersSize() + " references with " + verticalContainer.size() + " more entries");
                 }
                 try {
                     entry.add(verticalContainer);

--- a/source/net/yacy/peers/Network.java
+++ b/source/net/yacy/peers/Network.java
@@ -71,7 +71,7 @@ public class Network
     // statics
     public static final ThreadGroup publishThreadGroup = new ThreadGroup("publishThreadGroup");
     public static final HashMap<String, String> seedUploadMethods = new HashMap<>();
-    public static final ConcurrentLog log = new ConcurrentLog("YACY");
+    public static final ConcurrentLog log = new ConcurrentLog("NETWORK");
     /** pseudo-random key derived from a time-interval while YaCy startup */
     public static long speedKey = 0;
     public static long magic = System.currentTimeMillis();

--- a/source/net/yacy/search/Switchboard.java
+++ b/source/net/yacy/search/Switchboard.java
@@ -4110,7 +4110,7 @@ public final class Switchboard extends serverSwitch {
         final long kbytesUp = ConnectionInfo.getActiveUpbytes() / 1024;
         // accumulate RWIs to transmission buffer
         if ( this.dhtDispatcher.bufferSize() > this.peers.scheme.verticalPartitions() ) {
-            this.log.info("dhtTransferJob: no selection, too many entries in transmission buffer: "
+            this.log.fine("dhtTransferJob: no selection, too many entries in transmission buffer: "
                     + this.dhtDispatcher.bufferSize());
         } else if ( MemoryControl.available() < 1024 * 1024 * 25 ) {
             this.log.info("dhtTransferJob: no selection, too less memory available : "
@@ -4148,7 +4148,7 @@ public final class Switchboard extends serverSwitch {
                             this.dhtMaxReferenceCount,
                             5000);
             hasDoneSomething = hasDoneSomething | enqueued;
-            this.log.info("dhtTransferJob: result from enqueueing: " + ((enqueued) ? "true" : "false"));
+            this.log.fine("dhtTransferJob: result from enqueueing: " + ((enqueued) ? "true" : "false"));
         }
 
         // check if we can deliver entries to other peers
@@ -4166,7 +4166,7 @@ public final class Switchboard extends serverSwitch {
         } else {
             final boolean dequeued = this.dhtDispatcher.dequeueContainer();
             hasDoneSomething = hasDoneSomething | dequeued;
-            this.log.info("dhtTransferJob: result from dequeueing: " + ((dequeued) ? "true" : "false"));
+            this.log.fine("dhtTransferJob: result from dequeueing: " + ((dequeued) ? "true" : "false"));
         }
         return hasDoneSomething;
     }


### PR DESCRIPTION
In an effort to unclutter the log files, I did followig small changes:
- changed the network-related messages from keyword `YACY` to more descriptive `NETWORK`
- changed the repeating loglines about DHT selection to loglevel `fine` (these many single-liners about DHT priority and RWI extensions are good only for debug, not for the regular run)
- changed the peerping messages to loglevel `fine` (could be `config` as well, but there should be some granularity to distinguish between more important messages from these cluttering common ones)
- added a `NETWORK` category into the default `yacy.logging` file
- added a `FINER` and `FINEST` loglevels to default logging file, because they are used in the code, but not documented

Could be a part of solution for #611.

RWI and CRAWLER (as proposed in #414) should be categorised later and logging cleaned in a way that everything could be switched on/off by config file in a neat way.