### PR TITLE
Add setting for DHT receive loadprereq insted of hardcoded load < 2.0

### DIFF
--- a/defaults/yacy.init
+++ b/defaults/yacy.init
@@ -691,6 +691,7 @@ collection=user
 20_dhtdistribution_busysleep=15000
 20_dhtdistribution_memprereq=12582912
 20_dhtdistribution_loadprereq=2.0
+20_dhtreceive_loadprereq=2.0
 30_peerping_idlesleep=30000
 30_peerping_busysleep=30000
 30_peerping_memprereq=2097152

--- a/source/net/yacy/htroot/yacy/transferRWI.java
+++ b/source/net/yacy/htroot/yacy/transferRWI.java
@@ -102,7 +102,8 @@ public final class transferRWI {
             return prop;
         }
         // load tests
-        if (Memory.getSystemLoadAverage() > 2.0 || MemoryControl.shortStatus()) {
+        final float maxReceiveLoad = sb.getConfigFloat(SwitchboardConstants.INDEX_RECEIVE_LOADPREREQ, 2.0f);
+        if (Memory.getSystemLoadAverage() > maxReceiveLoad || MemoryControl.shortStatus()) {
             // check also Protocol.metadataRetrievalRunning.get() > 0 ?
             result = "too high load"; // don't tell too much details
             prop.put("result", result);

--- a/source/net/yacy/search/SwitchboardConstants.java
+++ b/source/net/yacy/search/SwitchboardConstants.java
@@ -82,6 +82,7 @@ public final class SwitchboardConstants {
     public static final String INDEX_DIST_LOADPREREQ        = "20_dhtdistribution_loadprereq";
     public static final String INDEX_DIST_IDLESLEEP         = "20_dhtdistribution_idlesleep";
     public static final String INDEX_DIST_BUSYSLEEP         = "20_dhtdistribution_busysleep";
+    public static final String INDEX_RECEIVE_LOADPREREQ     = "20_dhtreceive_loadprereq";
     // 30_peerping
     /**
      * <p><code>public static final String <strong>PEER_PING</strong> = "30_peerping"</code></p>


### PR DESCRIPTION
This helps to run full-fledged Yacy on servers as a side project