### PR TITLE
fix: Remove SayAt.Me Link

### DIFF
--- a/htroot/Steering.html
+++ b/htroot/Steering.html
@@ -190,8 +190,6 @@ XDtoU7vQ/wIAAP//AwBb7ktEXQ4nqQAAAABJRU5ErkJggg==" width="128" height="64" alt="K
       <p>We don't track YaCy users, YaCy does not send 'home-pings', we do not even know how many people use YaCy as their private search engine.<br/>
       Therefore we like to ask you: do you like YaCy? Will you use it again... if not, why? Is it possible that we change a bit to suit your needs?</p>
       <p>Please send us feed-back about your experience with an<br/>
-      <a href="http://sayat.me/YaCy" target="_blank">anonymous message</a><br/>
-      or a<br/>
       posting to our <a href="https://community.searchlab.eu" target="_blank">web forums</a><br/>
       or a<br/>
       <a href="https://github.com/yacy/yacy_search_server/issues" target="_blank">bug report</a>!</p>


### PR DESCRIPTION
closes #632 

This MR removes the SayAt.Me from the steering page.