### PR TITLE
Reduce Docker Image Size

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,12 +6,14 @@
 # run with
 # docker run -d --name yacy -p 8090:8090 -p 8443:8443 -v yacy_data:/opt/yacy_search_server/DATA --log-opt max-size=200m --log-opt max-file=2 yacy/yacy_search_server:latest
 
-
+## build base
+FROM eclipse-temurin:11-jdk-jammy AS base
+RUN apt-get update && apt-get install -yq wkhtmltopdf imagemagick xvfb ghostscript && rm -rf /var/lib/apt/lists/*
 
 ## build app
-FROM eclipse-temurin:11-jdk-jammy AS appbuilder
+FROM base AS appbuilder
 
-RUN apt-get update && apt-get install -yq ant git curl wkhtmltopdf imagemagick xvfb ghostscript && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -yq ant git curl && rm -rf /var/lib/apt/lists/*
 RUN java -version
 
 WORKDIR /opt
@@ -20,8 +22,12 @@ COPY . /opt/yacy_search_server/
 RUN ant compile -f /opt/yacy_search_server/build.xml && \
     apt-get purge -yq --auto-remove ant && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    rm -rf /opt/yacy_search_server/.git
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt/yacy_search_server/
+RUN git rev-parse HEAD > .git/shallow && \
+    git tag -l | xargs git tag -d && \
+    git gc --prune=now
 
 # Set initial admin password: "yacy" (encoded with custom yacy md5 function net.yacy.cora.order.Digest.encodeMD5Hex())
 RUN sed -i "/adminAccountBase64MD5=/c\adminAccountBase64MD5=MD5:8cffbc0d66567a0987a4aba1ec46d63c" /opt/yacy_search_server/defaults/yacy.init && \
@@ -31,16 +37,13 @@ RUN sed -i "/adminAccountBase64MD5=/c\adminAccountBase64MD5=MD5:8cffbc0d66567a09
 
 
 ## build dist
-FROM eclipse-temurin:11-jre-jammy
+FROM base
 LABEL maintainer="Michael Peter Christen <mc@yacy.net>"
 
-RUN apt-get update && apt-get install -yq wkhtmltopdf imagemagick xvfb ghostscript && rm -rf /var/lib/apt/lists/*
-
+RUN adduser --system --group --no-create-home --disabled-password yacy
 WORKDIR /opt
-COPY . /opt/yacy_search_server/
-COPY --from=appbuilder /opt/yacy_search_server /opt/yacy_search_server
+COPY --chown=yacy:yacy --from=appbuilder /opt/yacy_search_server /opt/yacy_search_server
 
-RUN adduser --system --group --no-create-home --disabled-password yacy && chown yacy:yacy -R /opt/yacy_search_server
 EXPOSE 8090 8443
 VOLUME ["/opt/yacy_search_server/DATA"]
 USER yacy


### PR DESCRIPTION
Reduces standard Docker image size from ~3.2 GiB to ~1.2 GiB

This PR does the following to reduce image size:

1. Reduce  .git directory size in final image
    - Performs in-place shallow clone by keeping only the HEAD commit and pruning unlinked objects
    - Drops .git repository pack files from 800 MiB to roughly 30 MiB
    - .git is kept as it (supposedly) is read at runtime in yacyBuild.properties:ReleaseStub (https://github.com/yacy/yacy_search_server/issues/566) 
 2. Set CHMOD permissions during multi-stage copy
    - Docker BuildKit now supports --chmod and --chown parameters for the COPY function
    - The separate COPY and chown commands are now merged to avoid duplicating the 1 GiB /opt/yacy_search_server directory due to the permission changes 
 3. Base Image for OS dependencies
    - An additional base image build stage was created to avoid re-installing common OS dependencies in appbuilder and final stages
