### PR TITLE
Fix autocrawler crashing

### DIFF
--- a/htroot/Autocrawl_p.html
+++ b/htroot/Autocrawl_p.html
@@ -20,7 +20,7 @@
     			#(changed)#::<dt></dt><dd><span class="error">You need to restart for some settings to be applied</span></dd>#(/changed)#
     			<dt>Enable Autocrawler:</dt>
     			<dd><input id="autocrawlEnable" name="autocrawlEnable" type="checkbox" #(autocrawlEnable)#::checked="checked"#(/autocrawlEnable)# /></dd>
-    			<dt>Deep crawl every:</dt>
+    			<dt>Deep crawl every Nth document:</dt>
     			<dd>
     				<input id="autocrawlRatio" name="autocrawlRatio" type="number" min="1" max="500" step="1" size="2" maxlength="2" value="#[autocrawlRatio]#" />
     				Warning: if this is bigger than "Rows to fetch" only shallow crawls will run.

--- a/locales/master.lng.xlf
+++ b/locales/master.lng.xlf
@@ -211,7 +211,7 @@
        <source>Enable Autocrawler:</source>
     </trans-unit>
     <trans-unit id="66a1bd2c" xml:space="preserve" approved="no" translate="yes">
-       <source>Deep crawl every:</source>
+       <source>Deep crawl every Nth document:</source>
     </trans-unit>
     <trans-unit id="2291c65d" xml:space="preserve" approved="no" translate="yes">
        <source>Warning: if this is bigger than "Rows to fetch" only shallow crawls will run.</source>

--- a/source/net/yacy/crawler/data/CrawlQueues.java
+++ b/source/net/yacy/crawler/data/CrawlQueues.java
@@ -608,6 +608,9 @@ public class CrawlQueues {
             int i = 0;
             int deepRatio = Integer.parseInt(this.sb.getConfig(SwitchboardConstants.AUTOCRAWL_RATIO, "50"));
             for (SolrDocument doc: resp.getResults()) {
+		if (doc == null) {
+		    continue;
+		}
                 boolean deep = false;
                 i++;
                 if( i % deepRatio == 0 ){

--- a/source/net/yacy/crawler/data/CrawlQueues.java
+++ b/source/net/yacy/crawler/data/CrawlQueues.java
@@ -617,6 +617,10 @@ public class CrawlQueues {
                     deep = true;
                 }
                 DigestURL url;
+		if (doc.getFieldValue("url_protocol_s") == null || doc.getFieldValue("host_s") == null) {
+			//Skip this document if either of these values is null.
+			continue; 
+		}
                 final String u = doc.getFieldValue("url_protocol_s").toString() + "://" + doc.getFieldValue("host_s").toString();
                 try {
                     url = new DigestURL(u);


### PR DESCRIPTION
Hi!

I was for a couple of days testing how the AutoCrawler feature works and eventually noticed that it crashes almost immediately because of a `java.lang.NullPointerException`. Noticed also that there were some other people who also have probably come across this problem.

So heres a simple sanity check to the SolrDocument response to ensure that it's not null & verify that the fields we require are available.

Also noticed that there was an [issue](https://github.com/yacy/yacy_search_server/issues/548) commenting that these options are a bit unclear, and I don't blame them. So I made a tiny change to the text on the autocrawler page. Unfortunately, I cannot confidently make the two translations that will be missing after this, hopefully we can live with this.


Thanks!