### PR TITLE
Remove deprectated JAVA_ARGS

### DIFF
--- a/startYACY.sh
+++ b/startYACY.sh
@@ -177,9 +177,6 @@ then
     # JAVA_ARGS="$JAVA_ARGS -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC"
 elif [ $OS = "SunOS" ]
 then
-    # the UseConcMarkSweepGC option caused a full CPU usage - bug on Darwin.
-    # It was reported that the same option causes good performance on solaris.
-    JAVA_ARGS="$JAVA_ARGS -XX:+UseConcMarkSweepGC -XX:+CMSIncrementalMode"
     ENABLEHUGEPAGES=1
 fi 
 


### PR DESCRIPTION
Both JAVA_ARGS are obsolete since JDK14 and expired in JDK15. They are no longer work on modern illumos (SunOS) distributions. Additonal the comment mention Darwin which is not SunOS.