### PR TITLE
upgrade ivy to 2.5.3 (CVE fixes)

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -60,7 +60,7 @@
   <target name="install-ivy" description="--> install ivy">
     <local name="ivy.download.dir"/><property name="ivy.download.dir" value="${basedir}/ivy" />
     <local name="ivy.download.file"/><property name="ivy.download.file" value="${ivy.download.dir}/ivy.jar" />
-    <local name="ivy.download.version"/><property name="ivy.install.version" value="2.5.0"/>
+    <local name="ivy.download.version"/><property name="ivy.install.version" value="2.5.3"/>
     <local name="ivy.debian.file"/><property name="ivy.debian.file" value="/usr/share/java/ivy.jar" />
 
     <!-- Check whether ivy is already available as a Debian package -->

--- a/build.xml
+++ b/build.xml
@@ -401,6 +401,7 @@
   <target name="clean" description="make clean">
     <delete dir="${release_main}" failonerror="false"/>
     <delete failonerror="false">
+      <fileset dir="${basedir}/ivy" includes="**/*.jar" />
       <fileset dir="${lib}" includes="**/*.jar" excludes="org.restlet.jar" /> <!-- we cannot find the org.restlet.jar in maven -->
       <fileset dir="${src}" includes="**/*.class" />
       <fileset dir="${build}" includes="**/*.class" />


### PR DESCRIPTION
Upgrade old ivy to fix several CVE.

https://ant.apache.org/ivy/security.html