### PR TITLE
update metrics-core to 4.1.5 to use the correct version for Solr 9.0

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -25,7 +25,7 @@
       <dependency org="commons-codec" name="commons-codec" rev="1.15" />
       <dependency org="commons-io" name="commons-io" rev="2.17.0" />
       <dependency org="commons-logging" name="commons-logging" rev="1.2" />
-      <dependency org="io.dropwizard.metrics" name="metrics-core" rev="3.2.2"/>
+      <dependency org="io.dropwizard.metrics" name="metrics-core" rev="4.1.5"/>
       <dependency org="io.dropwizard.metrics" name="metrics-jmx" rev="4.1.5" conf="compile->master"/>
       <dependency org="io.opentracing" name="opentracing-noop" rev="0.33.0"/>
       <dependency org="io.opentracing" name="opentracing-util" rev="0.33.0"/>


### PR DESCRIPTION
found with the help of the dependency tree