### PR TITLE
disable docker on forks

### DIFF
--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -17,6 +17,7 @@ permissions:
 
 jobs:
   docker:
+    if: github.repository == 'yacy/yacy_search_server'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Please disable Docker builds on forks, because forks can't upload the image.