### PR TITLE
Fix proper encoding in sendDirectory() function

### DIFF
--- a/source/net/yacy/http/servlets/YaCyDefaultServlet.java
+++ b/source/net/yacy/http/servlets/YaCyDefaultServlet.java
@@ -460,9 +460,9 @@ public class YaCyDefaultServlet extends HttpServlet  {
             return;
         }
 
-        final String base = URIUtil.addPaths(request.getRequestURI(), URIUtil.SLASH);
+        final String base = URIUtil.addEncodedPaths(request.getRequestURI(), URIUtil.SLASH);
 
-        final String dir = resource.getListHTML(base, pathInContext.length() > 1, null);
+        final String dir = resource.getListHTML(base, pathInContext.length() > 1, request.getQueryString());
         if (dir == null) {
             response.sendError(HttpServletResponse.SC_FORBIDDEN, "No directory");
             return;


### PR DESCRIPTION
This PR addresses a potential vulnerability in the sendDirectory() function in yacy_search_server/source/net/yacy/http/servlets/YaCyDefaultServlet.java sourced from yacy/yacy_search_server that could lead to potential cross-site scripting (XSS) attack. This issue, was originally reported and resolved in the repository via this commit https://github.com/jetty/jetty.project/commit/1532eba61d2276b2ed665719ce87f148e4a976da.

**Impact**
The code uses URIUtil.addPaths instead of URIUtil.addEncodedPaths. If addPaths does not properly encode special characters, it could introduce vulnerabilities such as path injection or XSS.

Please review at your convenience. Thank you!