### PR TITLE
support for /date search to be sorted by date published #622

### DIFF
--- a/source/net/yacy/cora/date/CustomISO8601Formatter.java
+++ b/source/net/yacy/cora/date/CustomISO8601Formatter.java
@@ -1,0 +1,27 @@
+package net.yacy.cora.date;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.StringTokenizer;
+
+public class CustomISO8601Formatter extends ISO8601Formatter {
+
+    public static final CustomISO8601Formatter CUSTOM_FORMATTER = new CustomISO8601Formatter();
+
+    @Override
+    public int getOffset(StringTokenizer t, int sign) {
+        String offset = t.nextToken();
+        if (offset.length() < 4) {
+            String token = t.nextToken();
+            if (token.equals(":")) {
+                offset += t.nextToken();
+            }
+        }
+        return sign * Integer.parseInt(offset) * 10 * 3600;
+    }
+
+    @Override
+    public Collection<String> getTimeSeparator() {
+        return Set.of("T", " ");
+    }
+}

--- a/source/net/yacy/cora/date/ISO8601Formatter.java
+++ b/source/net/yacy/cora/date/ISO8601Formatter.java
@@ -2,21 +2,21 @@
  *  ISO8601
  *  Copyright 2011 by Michael Peter Christen
  *  First released 2.1.2011 at https://yacy.net
- *
+ * <p>
  *  $LastChangedDate$
  *  $LastChangedRevision$
  *  $LastChangedBy$
- *
+ * <p>
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
  *  License as published by the Free Software Foundation; either
  *  version 2.1 of the License, or (at your option) any later version.
- *
+ * <p>
  *  This library is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  *  Lesser General Public License for more details.
- *
+ * <p>
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program in the file lgpl21.txt
  *  If not, see <http://www.gnu.org/licenses/>.
@@ -26,10 +26,7 @@ package net.yacy.cora.date;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.Locale;
-import java.util.StringTokenizer;
+import java.util.*;
 
 public class ISO8601Formatter extends AbstractFormatter implements DateFormatter {
 
@@ -112,7 +109,7 @@ public class ISO8601Formatter extends AbstractFormatter implements DateFormatter
             }
             // The standard says:
             // if there is an hour there has to be a minute and a timezone token, too.
-            if (t.nextToken().equals("T")) {
+            if (getTimeSeparator().contains(t.nextToken())) {
                 final int hour = Integer.parseInt(t.nextToken());
                 // no error, got hours
                 int min = 0;
@@ -148,7 +145,7 @@ public class ISO8601Formatter extends AbstractFormatter implements DateFormatter
                             // no legal TZ offset found
                             return cal;
                         }
-                        offset = sign * Integer.parseInt(t.nextToken()) * 10 * 3600;
+                        offset = getOffset(t, sign);
                     }
                     cal.set(Calendar.ZONE_OFFSET, offset);
                 }
@@ -168,6 +165,14 @@ public class ISO8601Formatter extends AbstractFormatter implements DateFormatter
         return cal;
     }
 
+    public int getOffset(StringTokenizer t, int sign) {
+        String offset = t.nextToken();
+        return sign * Integer.parseInt(offset) * 10 * 3600;
+    }
+
+    public Collection<String> getTimeSeparator() {
+        return Set.of("T");
+    }
 
     /**
      * Creates a String representation of a Date using the format defined

--- a/source/net/yacy/crawler/retrieval/Response.java
+++ b/source/net/yacy/crawler/retrieval/Response.java
@@ -878,7 +878,7 @@ public class Response {
                     this.url(), this.responseHeader == null ? null : this.responseHeader.getContentType(),
                     this.responseHeader == null ? StandardCharsets.UTF_8.name() : this.responseHeader.getCharacterEncoding(),
                     TagValency.EVAL, new HashSet<>(),
-                    new VocabularyScraper(), this.request.timezoneOffset(), this.request.depth(), this.content);
+                    new VocabularyScraper(), this.request.timezoneOffset(), this.request.depth(), this.content, null);
         } catch(final Parser.Failure e) {
             throw e;
         } catch (final Exception e) {

--- a/source/net/yacy/crawler/retrieval/StreamResponse.java
+++ b/source/net/yacy/crawler/retrieval/StreamResponse.java
@@ -27,6 +27,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Date;
 
 import net.yacy.cora.util.ConcurrentLog;
 import net.yacy.document.Document;
@@ -98,7 +99,7 @@ public class StreamResponse implements Closeable {
 	 *             when no parser support the content
 	 */
 	public Document[] parse() throws Parser.Failure {
-		return parseWithLimits(Integer.MAX_VALUE, Long.MAX_VALUE);
+		return parseWithLimits(Integer.MAX_VALUE, Long.MAX_VALUE, response.lastModified() == null ? null : response.lastModified());
 	}
 	
 	/**
@@ -122,7 +123,7 @@ public class StreamResponse implements Closeable {
 	 * @throws Parser.Failure
 	 *             when no parser support the content, or an error occurred while parsing
 	 */
-	public Document[] parseWithLimits(final int maxLinks, final long maxBytes) throws Parser.Failure {
+	public Document[] parseWithLimits(final int maxLinks, final long maxBytes, Date lastModified) throws Parser.Failure {
 		final String supportError = TextParser.supports(this.response.url(),
 				this.response.getResponseHeader() == null ? null : this.response.getResponseHeader().getContentType());
 		if (supportError != null) {
@@ -136,7 +137,7 @@ public class StreamResponse implements Closeable {
 			
 			return TextParser.parseWithLimits(this.response.url(), mimeType, charsetName,
 						this.response.getRequest().timezoneOffset(), this.response.getRequest().depth(),
-						this.response.size(), this.contentStream, maxLinks, maxBytes);
+						this.response.size(), this.contentStream, maxLinks, maxBytes, lastModified);
 		} catch(Parser.Failure e) {
 			throw e;
 		}catch (final Exception e) {

--- a/source/net/yacy/document/AbstractParser.java
+++ b/source/net/yacy/document/AbstractParser.java
@@ -2,17 +2,17 @@
  *  Parser
  *  Copyright 2010 by Michael Peter Christen, mc@yacy.net, Frankfurt am Main, Germany
  *  First released 29.6.2010 at https://yacy.net
- *
+ * <p>
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
  *  License as published by the Free Software Foundation; either
  *  version 2.1 of the License, or (at your option) any later version.
- *
+ * <p>
  *  This library is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  *  Lesser General Public License for more details.
- *
+ * <p>
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program in the file lgpl21.txt
  *  If not, see <http://www.gnu.org/licenses/>.
@@ -24,11 +24,7 @@
 package net.yacy.document;
 
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import net.yacy.cora.document.id.DigestURL;
 import net.yacy.cora.util.ConcurrentLog;
@@ -96,8 +92,9 @@ public abstract class AbstractParser implements Parser {
             final int timezoneOffset,
             final InputStream source,
             final int maxLinks,
-            final long maxBytes) throws UnsupportedOperationException, Failure, InterruptedException {
-        return parseWithLimits(location, mimeType, charset, TagValency.EVAL, new HashSet<String>(), scraper, timezoneOffset, source, maxLinks, maxBytes);
+            final long maxBytes,
+            final Date lastModified) throws UnsupportedOperationException, Failure, InterruptedException {
+        return parseWithLimits(location, mimeType, charset, TagValency.EVAL, new HashSet<String>(), scraper, timezoneOffset, source, maxLinks, maxBytes, lastModified);
     }
 
     @Override
@@ -111,9 +108,10 @@ public abstract class AbstractParser implements Parser {
             int timezoneOffset,
             InputStream source,
             int maxLinks,
-            long maxBytes)
+            long maxBytes,
+            Date lastModified)
             throws Failure, InterruptedException, UnsupportedOperationException {
-        return parseWithLimits(location, mimeType, charset, scraper, timezoneOffset, source, maxLinks, maxBytes);
+        return parseWithLimits(location, mimeType, charset, scraper, timezoneOffset, source, maxLinks, maxBytes, lastModified);
     }
 
     /**

--- a/source/net/yacy/document/Parser.java
+++ b/source/net/yacy/document/Parser.java
@@ -2,17 +2,17 @@
  *  Parser.java
  *  Copyright 2010 by Michael Peter Christen, mc@yacy.net, Frankfurt am Main, Germany
  *  First released 29.6.2010 at https://yacy.net
- *
+ * <p>
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
  *  License as published by the Free Software Foundation; either
  *  version 2.1 of the License, or (at your option) any later version.
- *
+ * <p>
  *  This library is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  *  Lesser General Public License for more details.
- *
+ * <p>
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program in the file lgpl21.txt
  *  If not, see <http://www.gnu.org/licenses/>.
@@ -24,6 +24,7 @@
 package net.yacy.document;
 
 import java.io.InputStream;
+import java.util.Date;
 import java.util.Set;
 
 import net.yacy.cora.document.id.DigestURL;
@@ -36,13 +37,13 @@ public interface Parser {
      * each parser must define a set of supported mime types
      * @return a set of mime type strings that are supported
      */
-    public Set<String> supportedMimeTypes();
+    Set<String> supportedMimeTypes();
 
     /**
      * each parser must define a set of supported file extensions
      * @return a set of file name extensions that are supported
      */
-    public Set<String> supportedExtensions();
+    Set<String> supportedExtensions();
 
     /**
      * parse an input stream
@@ -52,11 +53,11 @@ public interface Parser {
      * @param scraper an entity scraper to detect facets from text annotation context
      * @param timezoneOffset the local time zone offset
      * @param source a input stream
-     * @return a list of documents that result from parsing the source
+     * @return an array of documents that result from parsing the source
      * @throws Parser.Failure when the parser processing failed
      * @throws InterruptedException when the processing was interrupted before termination
      */
-    public Document[] parse(
+    Document[] parse(
             DigestURL url,
             String mimeType,
             String charset,
@@ -65,7 +66,7 @@ public interface Parser {
             InputStream source
             ) throws Parser.Failure, InterruptedException;
 
-    public Document[] parse(
+    Document[] parse(
             DigestURL url,
             String mimeType,
             String charset,
@@ -105,7 +106,7 @@ public interface Parser {
     *            result documents
     * @param maxBytes
     *            the maximum number of content bytes to process
-    * @return a list of documents that result from parsing the source, with
+    * @return an array of documents that result from parsing the source, with
     *         empty or null text.
     * @throws Parser.Failure
     *             when the parser processing failed
@@ -115,7 +116,7 @@ public interface Parser {
     *             when the parser implementation doesn't support parsing within
     *             limits
     */
-    public Document[] parseWithLimits(
+    Document[] parseWithLimits(
             DigestURL url,
             String mimeType,
             String charset,
@@ -123,28 +124,27 @@ public interface Parser {
             int timezoneOffset,
             InputStream source,
             int maxLinks,
-            long maxBytes)
-                    throws Parser.Failure, InterruptedException, UnsupportedOperationException;
+            long maxBytes,
+            Date lastModified) throws Parser.Failure, InterruptedException, UnsupportedOperationException;
 
-
-    public Document[] parseWithLimits(
-            final DigestURL location,
-            final String mimeType,
-            final String documentCharset,
-            final TagValency defaultValency,
-            final Set<String> valencySwitchTagNames,
-            final VocabularyScraper vocscraper,
-            final int timezoneOffset,
-            final InputStream sourceStream,
-            final int maxLinks,
-            final long maxBytes)
-                    throws Parser.Failure, InterruptedException, UnsupportedOperationException;
+    Document[] parseWithLimits(
+            DigestURL location,
+            String mimeType,
+            String documentCharset,
+            TagValency defaultValency,
+            Set<String> valencySwitchTagNames,
+            VocabularyScraper vocscraper,
+            int timezoneOffset,
+            InputStream sourceStream,
+            int maxLinks,
+            long maxBytes,
+            Date lastModified) throws Parser.Failure, InterruptedException, UnsupportedOperationException;
 
     /**
     * @return true when the parser implementation supports the
     *         parseWithLimits() operation.
     */
-    public boolean isParseWithLimitsSupported();
+    boolean isParseWithLimitsSupported();
 
     // methods to that shall make it possible to put Parser objects into a hashtable
 
@@ -152,27 +152,27 @@ public interface Parser {
      * get the name of the parser
      * @return the name of the parser
      */
-    public String getName();
+    String getName();
 
     /**
      * check equivalence of parsers; this simply tests equality of parser names
      * @return true when this parser is equivalent to o
      */
     @Override
-    public boolean equals(Object o);
+    boolean equals(Object o);
 
     /**
      * the hash code of a parser
      * @return the hash code of the parser name string
      */
     @Override
-    public int hashCode();
+    int hashCode();
 
     /**
      * a parser warning
      * thrown as an exception
      */
-    public class Failure extends Exception {
+    class Failure extends Exception {
 
         private static final long serialVersionUID = 2278214953869122883L;
         private MultiProtocolURL url = null;

--- a/source/net/yacy/document/TextParser.java
+++ b/source/net/yacy/document/TextParser.java
@@ -2,17 +2,17 @@
  *  TextParser.java
  *  Copyright 2009 by Michael Peter Christen, mc@yacy.net, Frankfurt am Main, Germany
  *  First released 09.07.2009 at https://yacy.net
- *
+ * <p>
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
  *  License as published by the Free Software Foundation; either
  *  version 2.1 of the License, or (at your option) any later version.
- *
+ * <p>
  *  This library is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  *  Lesser General Public License for more details.
- *
+ * <p>
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program in the file lgpl21.txt
  *  If not, see <http://www.gnu.org/licenses/>.
@@ -74,6 +74,8 @@ import net.yacy.document.parser.images.metadataImageParser;
 import net.yacy.document.parser.images.svgParser;
 import net.yacy.kelondro.util.FileUtils;
 import net.yacy.kelondro.util.MemoryControl;
+
+import java.util.*;
 
 public final class TextParser {
 
@@ -188,7 +190,8 @@ public final class TextParser {
             final VocabularyScraper scraper,
             final int timezoneOffset,
             final int depth,
-            final File sourceFile
+            final File sourceFile,
+            final Date lastModified
             ) throws InterruptedException, Parser.Failure {
 
         BufferedInputStream sourceStream = null;
@@ -201,7 +204,7 @@ public final class TextParser {
                 throw new Parser.Failure(errorMsg, location);
             }
             sourceStream = new BufferedInputStream(new FileInputStream(sourceFile));
-            docs = parseSource(location, mimeType, charset, defaultValency, valencySwitchTagNames, scraper, timezoneOffset, depth, sourceFile.length(), sourceStream);
+            docs = parseSource(location, mimeType, charset, defaultValency, valencySwitchTagNames, scraper, timezoneOffset, depth, sourceFile.length(), sourceStream, lastModified);
         } catch (final Exception e) {
             if (e instanceof InterruptedException) throw (InterruptedException) e;
             if (e instanceof Parser.Failure) throw (Parser.Failure) e;
@@ -223,7 +226,8 @@ public final class TextParser {
             final VocabularyScraper scraper,
             final int timezoneOffset,
             final int depth,
-            final byte[] content
+            final byte[] content,
+            final Date lastModified
             ) throws Parser.Failure {
         if (AbstractParser.log.isFine()) AbstractParser.log.fine("Parsing '" + location + "' from byte-array");
         mimeType = normalizeMimeType(mimeType);
@@ -237,7 +241,7 @@ public final class TextParser {
         }
         assert !idioms.isEmpty() : "no parsers applied for url " + location.toNormalform(true);
 
-        final Document[] docs = parseSource(location, mimeType, idioms, charset, defaultValency, valencySwitchTagNames, scraper, timezoneOffset, depth, content, Integer.MAX_VALUE, Long.MAX_VALUE);
+        final Document[] docs = parseSource(location, mimeType, idioms, charset, defaultValency, valencySwitchTagNames, scraper, timezoneOffset, depth, content, Integer.MAX_VALUE, Long.MAX_VALUE, lastModified);
 
         return docs;
     }
@@ -254,7 +258,8 @@ public final class TextParser {
             final VocabularyScraper scraper,
             final int timezoneOffset,
             final int depth,
-            final byte[] content
+            final byte[] content,
+            final Date lastModified
             ) throws Parser.Failure {
         if (AbstractParser.log.isFine()) {
             AbstractParser.log.fine("Parsing '" + location + "' from byte-array, applying only the generic parser");
@@ -263,7 +268,7 @@ public final class TextParser {
         final Set<Parser> idioms = new HashSet<>();
         idioms.add(TextParser.genericIdiom);
 
-        return parseSource(location, mimeType, idioms, charset, defaultValency, valencySwitchTagNames, scraper, timezoneOffset, depth, content, Integer.MAX_VALUE, Long.MAX_VALUE);
+        return parseSource(location, mimeType, idioms, charset, defaultValency, valencySwitchTagNames, scraper, timezoneOffset, depth, content, Integer.MAX_VALUE, Long.MAX_VALUE, lastModified);
     }
 
     private static Document[] parseSource(
@@ -278,7 +283,8 @@ public final class TextParser {
             final long contentLength,
             final InputStream sourceStream,
             final int maxLinks,
-            final long maxBytes
+            final long maxBytes,
+            final Date lastModified
             ) throws Parser.Failure {
         if (AbstractParser.log.isFine()) AbstractParser.log.fine("Parsing '" + location + "' from stream");
         mimeType = normalizeMimeType(mimeType);
@@ -334,7 +340,7 @@ public final class TextParser {
 
                     try {
                         return parseSource(location, mimeType, parser, charset, defaultValency, valencySwitchTagNames, scraper, timezoneOffset,
-                                nonCloseInputStream, maxLinks, maxBytes);
+                                nonCloseInputStream, maxLinks, maxBytes, lastModified);
                     } catch (final Parser.Failure e) {
                         /* Try to reset the marked stream. If the failed parser has consumed too many bytes :
                          * too bad, the marks is invalid and process fails now with an IOException */
@@ -395,7 +401,7 @@ public final class TextParser {
         } catch (final IOException e) {
             throw new Parser.Failure(e.getMessage(), location);
         }
-        final Document[] docs = parseSource(location, mimeType, idioms, charset, defaultValency, valencySwitchTagNames, scraper, timezoneOffset, depth, b, maxLinks, maxBytes);
+        final Document[] docs = parseSource(location, mimeType, idioms, charset, defaultValency, valencySwitchTagNames, scraper, timezoneOffset, depth, b, maxLinks, maxBytes, lastModified);
 
         return docs;
     }
@@ -410,9 +416,10 @@ public final class TextParser {
             final int timezoneOffset,
             final int depth,
             final long contentLength,
-            final InputStream sourceStream) throws Parser.Failure {
+            final InputStream sourceStream,
+            final Date lastModified) throws Parser.Failure {
         return parseSource(location, mimeType, charset, defaultValency, valencySwitchTagNames, scraper, timezoneOffset, depth, contentLength, sourceStream,
-                Integer.MAX_VALUE, Long.MAX_VALUE);
+                Integer.MAX_VALUE, Long.MAX_VALUE, lastModified);
     }
 
     /**
@@ -424,14 +431,15 @@ public final class TextParser {
      * @param location the URL of the source
      * @param mimeType the mime type of the source, if known
      * @param charset the charset name of the source, if known
-     * @param ignoreClassNames an eventual set of CSS class names whose matching html elements content should be ignored
+     * @param defaultValency the valency default; should be TagValency.EVAL by default
+     * @param valencySwitchTagNames the valency switch tag names
      * @param timezoneOffset the local time zone offset
      * @param depth the current depth of the crawl
      * @param contentLength the length of the source, if known (else -1 should be used)
      * @param sourceStream a input stream
      * @param maxLinks the maximum total number of links to parse and add to the result documents
      * @param maxBytes the maximum number of content bytes to process
-     * @return a list of documents that result from parsing the source, with empty or null text.
+     * @return an array of documents that result from parsing the source, with empty or null text.
      * @throws Parser.Failure when the parser processing failed
      */
     public static Document[] parseWithLimits(
@@ -445,9 +453,10 @@ public final class TextParser {
             final long contentLength,
             final InputStream sourceStream,
             final int maxLinks,
-            final long maxBytes) throws Parser.Failure{
+            final long maxBytes,
+            final Date lastModified) throws Parser.Failure{
         return parseSource(location, mimeType, charset, defaultValency, valencySwitchTagNames, new VocabularyScraper(), timezoneOffset, depth, contentLength,
-                sourceStream, maxLinks, maxBytes);
+                sourceStream, maxLinks, maxBytes, lastModified);
     }
 
     /**
@@ -471,9 +480,9 @@ public final class TextParser {
     public static Document[] parseWithLimits(
             final DigestURL location, final String mimeType, final String charset,
             final int timezoneOffset, final int depth, final long contentLength, final InputStream sourceStream, final int maxLinks,
-            final long maxBytes) throws Parser.Failure{
-        return parseSource(location, mimeType, charset, TagValency.EVAL, new HashSet<String>(), new VocabularyScraper(), timezoneOffset, depth, contentLength,
-                sourceStream, maxLinks, maxBytes);
+            final long maxBytes, final Date lastModified) throws Parser.Failure {
+        return parseSource(location, mimeType, charset, TagValency.EVAL, new HashSet<>(), new VocabularyScraper(), timezoneOffset, depth, contentLength,
+                sourceStream, maxLinks, maxBytes, lastModified);
     }
 
     /**
@@ -501,7 +510,8 @@ public final class TextParser {
             final int timezoneOffset,
             final InputStream sourceStream,
             final int maxLinks,
-            final long maxBytes
+            final long maxBytes,
+            final Date lastModified
             ) throws Parser.Failure {
         if (AbstractParser.log.isFine()) AbstractParser.log.fine("Parsing '" + location + "' from stream");
         final String fileExt = MultiProtocolURL.getFileExtension(location.getFileName());
@@ -512,7 +522,7 @@ public final class TextParser {
         try {
             final Document[] docs;
             if(parser.isParseWithLimitsSupported()) {
-                docs = parser.parseWithLimits(location, mimeType, documentCharset, defaultValency, valencySwitchTagNames, scraper, timezoneOffset, sourceStream, maxLinks, maxBytes);
+                docs = parser.parseWithLimits(location, mimeType, documentCharset, defaultValency, valencySwitchTagNames, scraper, timezoneOffset, sourceStream, maxLinks, maxBytes, lastModified);
             } else {
                 /* Parser do not support partial parsing within limits : let's control it here*/
                 final InputStream limitedSource = new StrictLimitInputStream(sourceStream, maxBytes);
@@ -537,7 +547,7 @@ public final class TextParser {
      * @param sourceArray the resource content bytes
      * @param maxLinks the maximum total number of links to parse and add to the result documents
      * @param maxBytes the maximum number of content bytes to process
-     * @return a list of documents that result from parsing the source
+     * @return an array of documents that result from parsing the source
      * @throws Parser.Failure when the source could not be parsed
      */
     private static Document[] parseSource(
@@ -552,7 +562,8 @@ public final class TextParser {
             final int depth,
             final byte[] sourceArray,
             final int maxLinks,
-            final long maxBytes
+            final long maxBytes,
+            final Date lastModified
             ) throws Parser.Failure {
         final String fileExt = MultiProtocolURL.getFileExtension(location.getFileName());
         if (AbstractParser.log.isFine()) AbstractParser.log.fine("Parsing " + location + " with mimeType '" + mimeType + "' and file extension '" + fileExt + "' from byte[]");
@@ -574,7 +585,7 @@ public final class TextParser {
                 }
                 try {
                     if(parser.isParseWithLimitsSupported()) {
-                        docs = parser.parseWithLimits(location, mimeType, documentCharset, defaultValency, valencySwitchTagNames, scraper, timezoneOffset, bis, maxLinks, maxBytes);
+                        docs = parser.parseWithLimits(location, mimeType, documentCharset, defaultValency, valencySwitchTagNames, scraper, timezoneOffset, bis, maxLinks, maxBytes, lastModified);
                     } else {
                         /* Partial parsing is not supported by this parser : check content length now */
                         if(sourceArray.length > maxBytes) {

--- a/source/net/yacy/document/importer/MediawikiImporter.java
+++ b/source/net/yacy/document/importer/MediawikiImporter.java
@@ -2,19 +2,19 @@
  *  MediawikiImporter
  *  Copyright 2008 by Michael Peter Christen
  *  First released 20.11.2008 at https://yacy.net
- *
+ * <p>
  *  This is a part of YaCy, a peer-to-peer based web search engine
- *
+ * <p>
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
  *  License as published by the Free Software Foundation; either
  *  version 2.1 of the License, or (at your option) any later version.
- *
+ * <p>
  *  This library is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  *  Lesser General Public License for more details.
- *
+ * <p>
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program in the file lgpl21.txt
  *  If not, see <http://www.gnu.org/licenses/>.
@@ -537,7 +537,8 @@ public class MediawikiImporter extends Thread implements Importer {
         public void genDocument() throws Parser.Failure {
             try {
                 this.url = new AnchorURL(this.urlStub + this.title);
-                final Document[] parsed = TextParser.parseSource(this.url, "text/html", StandardCharsets.UTF_8.name(), TagValency.EVAL, new HashSet<>(), new VocabularyScraper(), 0, 1, UTF8.getBytes(this.html));
+                final Document[] parsed = TextParser.parseSource(this.url, "text/html", StandardCharsets.UTF_8.name(),
+                        TagValency.EVAL, new HashSet<>(), new VocabularyScraper(), 0, 1, UTF8.getBytes(this.html), null);
                 this.document = Document.mergeDocuments(this.url, "text/html", parsed);
                 // the wiki parser is not able to find the proper title in the source text, so it must be set here
                 this.document.setTitle(this.title);

--- a/source/net/yacy/document/parser/AbstractCompressorParser.java
+++ b/source/net/yacy/document/parser/AbstractCompressorParser.java
@@ -85,7 +85,7 @@ public abstract class AbstractCompressorParser extends AbstractParser implements
             final InputStream source) throws Parser.Failure, InterruptedException {
 
         return parseWithLimits(location, mimeType, charset, scraper, timezoneOffset, source, Integer.MAX_VALUE,
-                Long.MAX_VALUE);
+                Long.MAX_VALUE, null);
     }
 
     @Override
@@ -99,7 +99,8 @@ public abstract class AbstractCompressorParser extends AbstractParser implements
             final int timezoneOffset,
             final InputStream source,
             final int maxLinks,
-            final long maxBytes) throws Parser.Failure {
+            final long maxBytes,
+            final Date lastModified) throws Parser.Failure {
         Document maindoc;
         final CompressorInputStream compressedInStream;
         try {
@@ -152,17 +153,17 @@ public abstract class AbstractCompressorParser extends AbstractParser implements
      * Parse content in an open stream uncompressing on the fly a compressed
      * resource.
      *
-     * @param location           the URL of the compressed resource
-     * @param charset            the charset name if known
-     * @param ignoreClassNames   an eventual set of CSS class names whose matching
-     *                           html elements content should be ignored
-     * @param timezoneOffset     the local time zone offset
-     * @param compressedInStream an open stream uncompressing on the fly the
-     *                           compressed content
-     * @param maxLinks           the maximum total number of links to parse and add
-     *                           to the result documents
-     * @param maxBytes           the maximum number of content bytes to process
-     * @return a list of documents that result from parsing the source, with empty
+     * @param location              the URL of the compressed resource
+     * @param charset               the charset name if known
+     * @param defaultValency        the valency default; should be TagValency.EVAL by default
+     * @param valencySwitchTagNames the valency switch tag names
+     * @param timezoneOffset        the local time zone offset
+     * @param compressedInStream    an open stream uncompressing on the fly the
+     *                              compressed content
+     * @param maxLinks              the maximum total number of links to parse and add
+     *                              to the result documents
+     * @param maxBytes              the maximum number of content bytes to process
+     * @return an array of documents that result from parsing the source, with empty
      *         or null text.
      * @throws Parser.Failure when the parser processing failed
      */
@@ -195,7 +196,7 @@ public abstract class AbstractCompressorParser extends AbstractParser implements
              */
             return TextParser.parseWithLimits(
                     contentLocation, mime, charset, defaultValency, valencySwitchTagNames, timezoneOffset, depth,
-                    -1, compressedInStream, maxLinks, maxBytes);
+                    -1, compressedInStream, maxLinks, maxBytes, null);
         } catch (final MalformedURLException e) {
             throw new Parser.Failure("Unexpected error while parsing compressed file. " + e.getMessage(), location);
         }

--- a/source/net/yacy/document/parser/GenericXMLParser.java
+++ b/source/net/yacy/document/parser/GenericXMLParser.java
@@ -154,7 +154,7 @@ public class GenericXMLParser extends AbstractParser implements Parser {
      */
     @Override
     public Document[] parseWithLimits(DigestURL location, String mimeType, String charsetName, VocabularyScraper scraper,
-    		int timezoneOffset, InputStream source, int maxLinks, long maxBytes)
+    		int timezoneOffset, InputStream source, int maxLinks, long maxBytes, Date lastModified)
     		throws Failure, InterruptedException, UnsupportedOperationException {
     	/* Limit the size of the in-memory buffer to at most 25% of the available memory :
     	 * because some room is needed, and before being garbage collected the buffer will be converted to a String, then to a byte array. 

--- a/source/net/yacy/document/parser/audioTagParser.java
+++ b/source/net/yacy/document/parser/audioTagParser.java
@@ -2,21 +2,21 @@
  *  mp3Parser
  *  Copyright 2012 by Stefan Foerster, Norderstedt, Germany
  *  First released 01.10.2012 at https://yacy.net
- *
+ * <p>
  * $LastChangedDate$
  * $LastChangedRevision$
  * $LastChangedBy$
- *
+ * <p>
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
  *  License as published by the Free Software Foundation; either
  *  version 2.1 of the License, or (at your option) any later version.
- *
+ * <p>
  *  This library is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  *  Lesser General Public License for more details.
- *
+ * <p>
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program in the file lgpl21.txt
  *  If not, see <http://www.gnu.org/licenses/>.
@@ -250,12 +250,12 @@ public class audioTagParser extends AbstractParser implements Parser {
             final int timezoneOffset,
             final InputStream source)
             throws Parser.Failure, InterruptedException {
-    	return parseWithLimits(location, mimeType, charset, scraper, timezoneOffset, source, Integer.MAX_VALUE, Long.MAX_VALUE);
+    	return parseWithLimits(location, mimeType, charset, scraper, timezoneOffset, source, Integer.MAX_VALUE, Long.MAX_VALUE, null);
     }
     
     @Override
     public Document[] parseWithLimits(final DigestURL location, final String mimeType, final String charset, final VocabularyScraper scraper,
-    		final int timezoneOffset, final InputStream source, final int maxLinks, final long maxBytes)
+    		final int timezoneOffset, final InputStream source, final int maxLinks, final long maxBytes, Date lastModified)
     		throws Failure, InterruptedException {
         String filename = location.getFileName();
         String fileExt = MultiProtocolURL.getFileExtension(filename);

--- a/source/net/yacy/document/parser/bzipParser.java
+++ b/source/net/yacy/document/parser/bzipParser.java
@@ -127,7 +127,7 @@ public class bzipParser extends AbstractParser implements Parser {
             // creating a new parser class to parse the unzipped content
             final String contentfilename = BZip2Utils.getUncompressedFileName(location.getFileName());
             final String mime = TextParser.mimeOf(MultiProtocolURL.getFileExtension(contentfilename));
-            final Document[] docs = TextParser.parseSource(location, mime, null, defaultValency, valencySwitchTagNames, scraper, timezoneOffset, 999, tempFile);
+            final Document[] docs = TextParser.parseSource(location, mime, null, defaultValency, valencySwitchTagNames, scraper, timezoneOffset, 999, tempFile, null);
             if (docs != null) maindoc.addSubDocuments(docs);
         } catch (final Exception e) {
             if (e instanceof InterruptedException) throw (InterruptedException) e;
@@ -206,7 +206,7 @@ public class bzipParser extends AbstractParser implements Parser {
             final DigestURL contentLocation = new DigestURL(location.getProtocol(), location.getHost(), location.getPort(), contentPath);
 
             /* Rely on the supporting parsers to respect the maxLinks and maxBytes limits on compressed content */
-            return TextParser.parseWithLimits(contentLocation, mime, charset, timezoneOffset, depth, -1, compressedInStream, maxLinks, maxBytes);
+            return TextParser.parseWithLimits(contentLocation, mime, charset, timezoneOffset, depth, -1, compressedInStream, maxLinks, maxBytes, null);
         } catch (MalformedURLException e) {
             throw new Parser.Failure("Unexpected error while parsing gzip file. " + e.getMessage(), location);
         }
@@ -215,7 +215,7 @@ public class bzipParser extends AbstractParser implements Parser {
     @SuppressWarnings("resource")
     @Override
     public Document[] parseWithLimits(final DigestURL location, final String mimeType, final String charset, final VocabularyScraper scraper,
-            final int timezoneOffset, final InputStream source, final int maxLinks, final long maxBytes)
+            final int timezoneOffset, final InputStream source, final int maxLinks, final long maxBytes, final Date lastModified)
             throws Parser.Failure {
         Document maindoc = null;
         BZip2CompressorInputStream zippedContent = null;

--- a/source/net/yacy/document/parser/genericParser.java
+++ b/source/net/yacy/document/parser/genericParser.java
@@ -2,21 +2,21 @@
  *  genericParser
  *  Copyright 2010 by Michael Peter Christen, mc@yacy.net, Frankfurt a. M., Germany
  *  First released 30.11.2010 at https://yacy.net
- *
+ * <p>
  * $LastChangedDate$
  * $LastChangedRevision$
  * $LastChangedBy$
- *
+ * <p>
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
  *  License as published by the Free Software Foundation; either
  *  version 2.1 of the License, or (at your option) any later version.
- *
+ * <p>
  *  This library is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  *  Lesser General Public License for more details.
- *
+ * <p>
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program in the file lgpl21.txt
  *  If not, see <http://www.gnu.org/licenses/>.
@@ -25,6 +25,7 @@
 package net.yacy.document.parser;
 
 import java.io.InputStream;
+import java.util.Date;
 
 import net.yacy.cora.document.id.DigestURL;
 import net.yacy.cora.document.id.MultiProtocolURL;
@@ -54,7 +55,7 @@ public class genericParser extends AbstractParser implements Parser {
             final InputStream source)
             throws Parser.Failure, InterruptedException {
     	/* Exactly the same implementation when applying limits as only tokens in the location URL are parsed */
-        return parseWithLimits(location, mimeType, charset, scraper, timezoneOffset, source, Integer.MAX_VALUE, Long.MAX_VALUE);
+        return parseWithLimits(location, mimeType, charset, scraper, timezoneOffset, source, Integer.MAX_VALUE, Long.MAX_VALUE, null);
     }
     
     @Override
@@ -64,8 +65,9 @@ public class genericParser extends AbstractParser implements Parser {
     
 	@Override
 	public Document[] parseWithLimits(final DigestURL location, final String mimeType, final String charset,
-			final VocabularyScraper scraper, final int timezoneOffset, final InputStream source, final int maxLinks,
-			final long maxBytes) throws Failure, InterruptedException, UnsupportedOperationException {
+                                      final VocabularyScraper scraper, final int timezoneOffset, final InputStream source, final int maxLinks,
+                                      final long maxBytes, final Date lastModified)
+            throws Failure, InterruptedException, UnsupportedOperationException {
         String filename = location.getFileName();
         final Document[] docs = new Document[]{new Document(
                 location,
@@ -85,7 +87,7 @@ public class genericParser extends AbstractParser implements Parser {
                 null,
                 null,
                 false,
-                null)};
+                lastModified)};
         return docs;
     }
 }

--- a/source/net/yacy/document/parser/gzipParser.java
+++ b/source/net/yacy/document/parser/gzipParser.java
@@ -130,7 +130,7 @@ public class gzipParser extends AbstractParser implements Parser {
             // creating a new parser class to parse the unzipped content
             final String contentfilename = GzipUtils.getUncompressedFileName(location.getFileName());
             final String mime = TextParser.mimeOf(MultiProtocolURL.getFileExtension(contentfilename));
-            Document[] docs = TextParser.parseSource(location, mime, null, defaultValency, valencySwitchTagNames, scraper, timezoneOffset, DEFAULT_DEPTH, tempFile);
+            Document[] docs = TextParser.parseSource(location, mime, null, defaultValency, valencySwitchTagNames, scraper, timezoneOffset, DEFAULT_DEPTH, tempFile, null);
             if (docs != null) maindoc.addSubDocuments(docs);
         } catch (final Exception e) {
             if (e instanceof InterruptedException) throw (InterruptedException) e;
@@ -148,7 +148,7 @@ public class gzipParser extends AbstractParser implements Parser {
      * @param location the parsed resource URL
      * @param mimeType the media type of the resource
      * @param charset the charset name if known
-     * @param an instance of gzipParser that is registered as the parser origin of the document
+     * @param parser an instance of gzipParser that is registered as the parser origin of the document
      * @return a Document instance
      */
     public static Document createMainDocument(final DigestURL location, final String mimeType, final String charset, final gzipParser parser) {
@@ -204,7 +204,7 @@ public class gzipParser extends AbstractParser implements Parser {
             final DigestURL contentLocation = new DigestURL(location.getProtocol(), location.getHost(), location.getPort(), contentPath);
 
             /* Rely on the supporting parsers to respect the maxLinks and maxBytes limits on compressed content */
-            return TextParser.parseWithLimits(contentLocation, mime, charset, timezoneOffset, depth, -1, compressedInStream, maxLinks, maxBytes);
+            return TextParser.parseWithLimits(contentLocation, mime, charset, timezoneOffset, depth, -1, compressedInStream, maxLinks, maxBytes, null);
         } catch (MalformedURLException e) {
             throw new Parser.Failure("Unexpected error while parsing gzip file. " + e.getMessage(), location);
         }
@@ -217,7 +217,7 @@ public class gzipParser extends AbstractParser implements Parser {
 
     @Override
     public Document[] parseWithLimits(final DigestURL location, final String mimeType, final String charset, final VocabularyScraper scraper,
-            final int timezoneOffset, final InputStream source, final int maxLinks, final long maxBytes)
+            final int timezoneOffset, final InputStream source, final int maxLinks, final long maxBytes, final Date lastModified)
             throws Parser.Failure {
         Document maindoc = null;
         GZIPInputStream zippedContent = null;

--- a/source/net/yacy/document/parser/html/ContentScraper.java
+++ b/source/net/yacy/document/parser/html/ContentScraper.java
@@ -1460,34 +1460,8 @@ public class ContentScraper extends AbstractScraper implements Scraper {
         return EMPTY_STRING;
     }
 
-    public Date getDate() {
-        String content;
-
-        // <meta name="date" content="YYYY-MM-DD..." />
-        content = this.metas.get("date");
-        if (content != null) try {return ISO8601Formatter.FORMATTER.parse(content, this.timezoneOffset).getTime();} catch (final ParseException e) {}
-
-        // <meta name="DC.date.modified" content="YYYY-MM-DD" />
-        content = this.metas.get("dc.date.modified");
-        if (content != null) try {return ISO8601Formatter.FORMATTER.parse(content, this.timezoneOffset).getTime();} catch (final ParseException e) {}
-
-        // <meta name="DC.date.created" content="YYYY-MM-DD" />
-        content = this.metas.get("dc.date.created");
-        if (content != null) try {return ISO8601Formatter.FORMATTER.parse(content, this.timezoneOffset).getTime();} catch (final ParseException e) {}
-
-        // <meta name="DC.date" content="YYYY-MM-DD" />
-        content = this.metas.get("dc.date");
-        if (content != null) try {return ISO8601Formatter.FORMATTER.parse(content, this.timezoneOffset).getTime();} catch (final ParseException e) {}
-
-        // <meta name="DC:date" content="YYYY-MM-DD" />
-        content = this.metas.get("dc:date");
-        if (content != null) try {return ISO8601Formatter.FORMATTER.parse(content, this.timezoneOffset).getTime();} catch (final ParseException e) {}
-
-        // <meta http-equiv="last-modified" content="YYYY-MM-DD" />
-        content = this.metas.get("last-modified");
-        if (content != null) try {return ISO8601Formatter.FORMATTER.parse(content, this.timezoneOffset).getTime();} catch (final ParseException e) {}
-
-        return new Date();
+    public Date getDate(Date lastModified) {
+        return ContentScraperDateUtil.getDate(root, metas, timezoneOffset, startDates, lastModified);
     }
 
     // parse location

--- a/source/net/yacy/document/parser/html/ContentScraperDateUtil.java
+++ b/source/net/yacy/document/parser/html/ContentScraperDateUtil.java
@@ -1,0 +1,150 @@
+package net.yacy.document.parser.html;
+
+import net.yacy.cora.date.CustomISO8601Formatter;
+import net.yacy.cora.document.id.DigestURL;
+import net.yacy.cora.storage.SizeLimitedMap;
+import net.yacy.cora.util.ConcurrentLog;
+
+import java.text.ParseException;
+import java.time.DateTimeException;
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ContentScraperDateUtil {
+
+    private final static ConcurrentLog log = new ConcurrentLog("SCRAPER_DATE");
+
+    private static final Pattern URL_DATE_REGEX =
+            Pattern.compile(
+                    "/(19\\d{2}|20\\d{2})[-/]?(0[1-9]|1[0-2]|January|February|March|April|May|June|July|August|September|October|November|December)((?:[-/]?(0[1-9]|[12]\\d|3[01]))?)/",
+                    Pattern.CASE_INSENSITIVE);
+
+    public static Date getDate(DigestURL root, SizeLimitedMap<String, String> metas, int timezoneOffset, List<Date> startDates, Date lastModified) {
+        var currentDate = new Date();
+
+        var date = new AtomicReference<Date>();
+
+        // root url like: https://denikn.cz/1188398/nova-socialni-sit-threads-ma-vazne-nedostatky-ale-dokonale-nacasovani-meta-ji-chce-nahradit-twitter/
+        parseDate("<script id=\"schema\" type=\"application/ld+json\">{...,\"datePublished\":\"2023-07-10T14:40:52+02:00\",..}</script>",
+                metas.get("script.datepublished"),
+                timezoneOffset, date);
+
+        parseDate("<meta name=\"article:published_time\" content=\"YYYY-MM-DD...\" />",
+                metas.get("article:published_time"),
+                timezoneOffset, date);
+
+        parseDate("<meta name=\"DC.date.issued\" content=\"YYYY-MM-DD...\" />",
+                metas.get("dc.date.issued"),
+                timezoneOffset, date);
+        parseDate("<meta name=\"DC.date.modified\" content=\"YYYY-MM-DD...\" />",
+                metas.get("dc.date.modified"),
+                timezoneOffset, date);
+        parseDate("<meta name=\"DC.date.created\" content=\"YYYY-MM-DD...\" />",
+                metas.get("dc.date.created"),
+                timezoneOffset, date);
+        parseDate("<meta name=\"DC.date\" content=\"YYYY-MM-DD...\" />",
+                metas.get("dc.date"),
+                timezoneOffset, date);
+
+        String content = root.toString();
+        if (date.get() == null && content != null) {
+            // Regex by https://github.com/codelucas/newspaper/blob/master/newspaper/urls.py
+            Matcher dateMatcher = URL_DATE_REGEX.matcher(content);
+            if (dateMatcher.find()) {
+                // root url like: http://www.dailytimes.com.pk/digital_images/400/2015-11-26/norway-return-number-of-asylum-seekers-to-pakistan-1448538771-7363.jpg
+                int year = Integer.parseInt(dateMatcher.group(1));
+                String monthPart = dateMatcher.group(2);
+                String dayPart = dateMatcher.group(4); // scraper will be null (or empty?) if the day is not present
+
+                int monthValue;
+                try {
+                    // Try parsing as integer (e.g., "01")
+                    monthValue = Integer.parseInt(monthPart);
+                } catch (NumberFormatException e) {
+                    // If not an integer, it's a month name (e.g., "January")
+                    monthValue = Month.valueOf(monthPart.toUpperCase(Locale.US)).getValue();
+                }
+
+                int dayValue;
+                if (dayPart != null && !dayPart.isEmpty()) {
+                    dayValue = Integer.parseInt(dayPart);
+                } else {
+                    dayValue = 1; // Deduce as the first day of the month
+                    log.info("Day part missing, deduced as the first day of the month in URL: +'" + content + "'");
+                }
+
+                try {
+                    LocalDate parsedDate = LocalDate.of(year, monthValue, dayValue);
+                    return CustomISO8601Formatter.CUSTOM_FORMATTER.parse(parsedDate.format(DateTimeFormatter.ISO_DATE), timezoneOffset).getTime();
+                } catch (DateTimeException | ParseException e) {
+                    log.warn("Error: " + e.getMessage() + " (probably invalid day for month)");
+                }
+            }
+        }
+
+        if (date.get() == null && lastModified != null) {
+            date.set(lastModified);
+        }
+
+        if (date.get() == null) {
+            // find the most frequent date in starDates in the content
+            date.set(findMostFrequentDate(startDates, currentDate));
+            if (date.get() != null) {
+                log.info("Publish date found in startDates in the page content with value: '" + date + "'");
+                return date.get();
+            }
+        } else {
+            return date.get();
+        }
+
+        log.info("Publish date not found, current date used: '" + currentDate + "'");
+
+        return currentDate;
+    }
+
+    private static void parseDate(String tag, String date, int timezoneOffset, AtomicReference<Date> result) {
+        if (result.get() != null) {
+            return;
+        }
+        if (date != null) {
+            try {
+                log.info("Publish date found according to: '" + tag + "' pattern with value: '" + date + "'");
+                result.set(CustomISO8601Formatter.CUSTOM_FORMATTER.parse(date, timezoneOffset).getTime());
+            } catch (final ParseException e) {
+                // Intentionally empty due to performance reasons
+            }
+        }
+    }
+
+    private static Date findMostFrequentDate(List<Date> dates, Date currentDate){
+        if (dates == null || dates.isEmpty()) {
+            return null; // Handle an empty or null list
+        }
+
+        Map<Date, Integer> dateCounts = new HashMap<>();
+        for (Date date : dates) {
+            dateCounts.put(date, dateCounts.getOrDefault(date, 0) + 1);
+        }
+
+        int maxCount = Collections.max(dateCounts.values()); // Find the maximum count
+
+        List<Date> maxDates = new java.util.ArrayList<>();
+        for (Map.Entry<Date, Integer> entry : dateCounts.entrySet()) {
+            if (entry.getValue() == maxCount && !entry.getKey().before(currentDate)) {
+                maxDates.add(entry.getKey());
+            }
+        }
+
+        if (maxDates.isEmpty()) {
+            return null;
+        }
+
+        return Collections.max(maxDates);
+    }
+
+}

--- a/source/net/yacy/document/parser/rssParser.java
+++ b/source/net/yacy/document/parser/rssParser.java
@@ -2,21 +2,21 @@
  *  rssParser.java
  *  Copyright 2010 by Michael Peter Christen, mc@yacy.net, Frankfurt am Main, Germany
  *  First released 20.08.2010 at https://yacy.net
- *
+ * <p>
  * $LastChangedDate$
  * $LastChangedRevision$
  * $LastChangedBy$
- *
+ * <p>
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
  *  License as published by the Free Software Foundation; either
  *  version 2.1 of the License, or (at your option) any later version.
- *
+ * <p>
  *  This library is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  *  Lesser General Public License for more details.
- *
+ * <p>
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program in the file lgpl21.txt
  *  If not, see <http://www.gnu.org/licenses/>.
@@ -28,12 +28,9 @@ package net.yacy.document.parser;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
+import jdk.jfr.DataAmount;
 import org.apache.commons.lang.StringUtils;
 
 import net.yacy.cora.document.feed.Hit;
@@ -163,7 +160,7 @@ public class rssParser extends AbstractParser implements Parser {
     
     @Override
     public Document[] parseWithLimits(final DigestURL url, final String mimeType, final String charset, final VocabularyScraper scraper,
-    		final int timezoneOffset, final InputStream source, final int maxLinks, final long maxBytes)
+									  final int timezoneOffset, final InputStream source, final int maxLinks, final long maxBytes, final Date lastModified)
     		throws Failure, InterruptedException, UnsupportedOperationException {
         RSSReader rssReader;
         try {

--- a/source/net/yacy/document/parser/tarParser.java
+++ b/source/net/yacy/document/parser/tarParser.java
@@ -2,21 +2,21 @@
  *  tarParser
  *  Copyright 2010 by Michael Peter Christen, mc@yacy.net, Frankfurt am Main, Germany
  *  First released 29.6.2010 at https://yacy.net
- *
+ * <p>
  * $LastChangedDate$
  * $LastChangedRevision$
  * $LastChangedBy$
- *
+ * <p>
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
  *  License as published by the Free Software Foundation; either
  *  version 2.1 of the License, or (at your option) any later version.
- *
+ * <p>
  *  This library is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  *  Lesser General Public License for more details.
- *
+ * <p>
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program in the file lgpl21.txt
  *  If not, see <http://www.gnu.org/licenses/>.
@@ -90,7 +90,7 @@ public class tarParser extends AbstractParser implements Parser {
         }
         TarArchiveEntry entry;
         final TarArchiveInputStream tis = new TarArchiveInputStream(source);
-        
+
         // create maindoc for this tar container
         final Document maindoc = createMainDocument(location, mimeType, charset, this);
         // loop through the elements in the tar file and parse every single file inside
@@ -102,21 +102,21 @@ public class tarParser extends AbstractParser implements Parser {
                 if (entry.isDirectory() || entry.getSize() <= 0) continue;
                 final String name = entry.getName();
                 final int idx = name.lastIndexOf('.');
-                final String mime = TextParser.mimeOf((idx > -1) ? name.substring(idx+1) : "");
+                final String mime = TextParser.mimeOf((idx > -1) ? name.substring(idx + 1) : "");
                 try {
                     tmp = FileUtils.createTempFile(this.getClass(), name);
                     FileUtils.copy(tis, tmp, entry.getSize());
-/*
- * Create an appropriate sub location to prevent unwanted fallback to the tarparser on resources included in the archive. 
- * We use the tar file name as the parent sub path. Example : http://host/archive.tar/name.
- * Indeed if we create a sub location with a '#' separator such as http://host/archive.tar#name, the
- * extension of the URL is still ".tar", thus incorrectly making the tar parser
- * as a possible parser for the sub resource.
- */
+                    /*
+                     * Create an appropriate sub location to prevent unwanted fallback to the tarparser on resources included in the archive.
+                     * We use the tar file name as the parent sub path. Example : http://host/archive.tar/name.
+                     * Indeed if we create a sub location with a '#' separator such as http://host/archive.tar#name, the
+                     * extension of the URL is still ".tar", thus incorrectly making the tar parser
+                     * as a possible parser for the sub resource.
+                     */
                     final DigestURL subLocation = new DigestURL(parentTarURL, name);
-                    final Document[] subDocs = TextParser.parseSource(subLocation, mime, null, defaultValency, valencySwitchTagNames, scraper, timezoneOffset,999, tmp);
+                    final Document[] subDocs = TextParser.parseSource(subLocation, mime, null, defaultValency, valencySwitchTagNames, scraper, timezoneOffset, 999, tmp, null);
                     if (subDocs == null) {
-                    continue;
+                        continue;
                     }
                     maindoc.addSubDocuments(subDocs);
                 } catch (final Parser.Failure e) {
@@ -132,148 +132,148 @@ public class tarParser extends AbstractParser implements Parser {
         return new Document[]{maindoc};
     }
 
-@Override
-public boolean isParseWithLimitsSupported() {
-return true;
-}
+    @Override
+    public boolean isParseWithLimitsSupported() {
+        return true;
+    }
 
-@Override
-public Document[] parseWithLimits(final DigestURL location, final String mimeType, final String charset,
-final VocabularyScraper scraper, final int timezoneOffset, final InputStream source, final int maxLinks,
-final long maxBytes) throws Failure, InterruptedException, UnsupportedOperationException {
+    @Override
+    public Document[] parseWithLimits(final DigestURL location, final String mimeType, final String charset,
+            final VocabularyScraper scraper, final int timezoneOffset, final InputStream source, final int maxLinks,
+            final long maxBytes, final Date lastModified) throws Failure, InterruptedException, UnsupportedOperationException {
 
-final DigestURL parentTarURL = createParentTarURL(location);
+        final DigestURL parentTarURL = createParentTarURL(location);
 
-final TarArchiveInputStream tis = new TarArchiveInputStream(source);
+        final TarArchiveInputStream tis = new TarArchiveInputStream(source);
 
-// create maindoc for this tar container
-final Document maindoc = createMainDocument(location, mimeType, charset, this);
+        // create maindoc for this tar container
+        final Document maindoc = createMainDocument(location, mimeType, charset, this);
 
-// loop through the elements in the tar file and parse every single file inside
-TarArchiveEntry entry;
-int totalProcessedLinks = 0;
-while (true) {
-try {
-entry = tis.getNextEntry();
-if (entry == null) {
-break;
-}
+        // loop through the elements in the tar file and parse every single file inside
+        TarArchiveEntry entry;
+        int totalProcessedLinks = 0;
+        while (true) {
+            try {
+                entry = tis.getNextEntry();
+                if (entry == null) {
+                    break;
+                }
 
-/*
- * We are here sure at least one entry has still to be processed : let's check
- * now the bytes limit as sub parsers applied on eventual previous entries may
- * not support partial parsing and would have thrown a Parser.Failure instead of
- * marking the document as partially parsed.
- */
-if (tis.getBytesRead() >= maxBytes) {
-maindoc.setPartiallyParsed(true);
-break;
-}
+                /*
+                 * We are here sure at least one entry has still to be processed : let's check
+                 * now the bytes limit as sub parsers applied on eventual previous entries may
+                 * not support partial parsing and would have thrown a Parser.Failure instead of
+                 * marking the document as partially parsed.
+                 */
+                if (tis.getBytesRead() >= maxBytes) {
+                    maindoc.setPartiallyParsed(true);
+                    break;
+                }
 
-if (entry.isDirectory() || entry.getSize() <= 0) {
-continue;
-}
-final String name = entry.getName();
-final int idx = name.lastIndexOf('.');
-final String mime = TextParser.mimeOf((idx > -1) ? name.substring(idx + 1) : "");
-try {
-/*
- * Rely on the supporting parsers to respect the maxLinks and maxBytes limits on
- * compressed content
- */
+                if (entry.isDirectory() || entry.getSize() <= 0) {
+                    continue;
+                }
+                final String name = entry.getName();
+                final int idx = name.lastIndexOf('.');
+                final String mime = TextParser.mimeOf((idx > -1) ? name.substring(idx + 1) : "");
+                try {
+                    /*
+                     * Rely on the supporting parsers to respect the maxLinks and maxBytes limits on
+                     * compressed content
+                     */
 
-/*
- * Create an appropriate sub location to prevent unwanted fallback to the
- * tarparser on resources included in the archive. We use the tar file name as
- * the parent sub path. Example : http://host/archive.tar/name. Indeed if we
- * create a sub location with a '#' separator such as
- * http://host/archive.tar#name, the extension of the URL is still ".tar", thus
- * incorrectly making the tar parser as a possible parser for the sub resource.
- */
-final DigestURL subLocation = new DigestURL(parentTarURL, name);
-final Document[] subDocs = TextParser.parseWithLimits(subLocation, mime, null, timezoneOffset, 999,
-entry.getSize(), tis, maxLinks - totalProcessedLinks, maxBytes - tis.getBytesRead());
+                    /*
+                     * Create an appropriate sub location to prevent unwanted fallback to the
+                     * tarparser on resources included in the archive. We use the tar file name as
+                     * the parent sub path. Example : http://host/archive.tar/name. Indeed if we
+                     * create a sub location with a '#' separator such as
+                     * http://host/archive.tar#name, the extension of the URL is still ".tar", thus
+                     * incorrectly making the tar parser as a possible parser for the sub resource.
+                     */
+                    final DigestURL subLocation = new DigestURL(parentTarURL, name);
+                    final Document[] subDocs = TextParser.parseWithLimits(subLocation, mime, null, timezoneOffset, 999,
+                            entry.getSize(), tis, maxLinks - totalProcessedLinks, maxBytes - tis.getBytesRead(), lastModified);
 
-/*
- * If the parser(s) did not consume all bytes in the entry, these ones will be
- * skipped by the next call to getNextTarEntry()
- */
-if (subDocs == null) {
-continue;
-}
-maindoc.addSubDocuments(subDocs);
-for (Document subDoc : subDocs) {
-if (subDoc.getAnchors() != null) {
-totalProcessedLinks += subDoc.getAnchors().size();
-}
-}
-/*
- * Check if a limit has been exceeded (we are sure to pass here when maxLinks
- * has been exceeded as this limit require parser support for partial parsing to
- * be detected)
- */
-if (subDocs[0].isPartiallyParsed()) {
-maindoc.setPartiallyParsed(true);
-break;
-}
-} catch (final Parser.Failure e) {
-AbstractParser.log.warn("tar parser entry " + name + ": " + e.getMessage());
-}
-} catch (final IOException e) {
-AbstractParser.log.warn("tar parser:" + e.getMessage());
-break;
-}
-}
-return new Document[] { maindoc };
-}
+                    /*
+                     * If the parser(s) did not consume all bytes in the entry, these ones will be
+                     * skipped by the next call to getNextTarEntry()
+                     */
+                    if (subDocs == null) {
+                        continue;
+                    }
+                    maindoc.addSubDocuments(subDocs);
+                    for (Document subDoc : subDocs) {
+                        if (subDoc.getAnchors() != null) {
+                            totalProcessedLinks += subDoc.getAnchors().size();
+                        }
+                    }
+                    /*
+                     * Check if a limit has been exceeded (we are sure to pass here when maxLinks
+                     * has been exceeded as this limit require parser support for partial parsing to
+                     * be detected)
+                     */
+                    if (subDocs[0].isPartiallyParsed()) {
+                        maindoc.setPartiallyParsed(true);
+                        break;
+                    }
+                } catch (final Parser.Failure e) {
+                    AbstractParser.log.warn("tar parser entry " + name + ": " + e.getMessage());
+                }
+            } catch (final IOException e) {
+                AbstractParser.log.warn("tar parser:" + e.getMessage());
+                break;
+            }
+        }
+        return new Document[]{maindoc};
+    }
 
-/**
- * Generate a parent URL to use for generating sub URLs on tar archive entries.
- * 
- * @param tarURL
- *            the URL of the tar archive
- * @return an URL ending with a "/" suitable as a base URL for archive entries
- */
-private DigestURL createParentTarURL(final DigestURL tarURL) {
-String locationStr = tarURL.toNormalform(false);
-if (!locationStr.endsWith("/")) {
-locationStr += "/";
-}
-DigestURL parentTarURL;
-try {
-parentTarURL = new DigestURL(locationStr);
-} catch (MalformedURLException e1) {
-/* This should not happen */
-parentTarURL = tarURL;
-}
-return parentTarURL;
-}
+    /**
+     * Generate a parent URL to use for generating sub URLs on tar archive entries.
+     *
+     * @param tarURL
+     *            the URL of the tar archive
+     * @return an URL ending with a "/" suitable as a base URL for archive entries
+     */
+    private DigestURL createParentTarURL(final DigestURL tarURL) {
+        String locationStr = tarURL.toNormalform(false);
+        if (!locationStr.endsWith("/")) {
+            locationStr += "/";
+        }
+        DigestURL parentTarURL;
+        try {
+            parentTarURL = new DigestURL(locationStr);
+        } catch (MalformedURLException e1) {
+            /* This should not happen */
+            parentTarURL = tarURL;
+        }
+        return parentTarURL;
+    }
 
-/**
- * Create the main resulting parsed document for a tar container
- * 
- * @param location
- *            the parsed resource URL
- * @param mimeType
- *            the media type of the resource
- * @param charset
- *            the charset name if known
- * @param parser
- *            instance of tarParser that is registered as the parser origin of
- *            the document
- * @return a Document instance
- */
-public static Document createMainDocument(final DigestURL location, final String mimeType, final String charset,
-final tarParser parser) {
-final String filename = location.getFileName();
-final Document maindoc = new Document(location, mimeType, charset, parser, null, null,
-AbstractParser
-.singleList(filename.isEmpty() ? location.toTokens() : MultiProtocolURL.unescape(filename)), // title
-null, null, null, null, 0.0d, 0.0d, (Object) null, null, null, null, false, new Date());
-return maindoc;
-}
+    /**
+     * Create the main resulting parsed document for a tar container
+     *
+     * @param location
+     *            the parsed resource URL
+     * @param mimeType
+     *            the media type of the resource
+     * @param charset
+     *            the charset name if known
+     * @param parser
+     *            instance of tarParser that is registered as the parser origin of
+     *            the document
+     * @return a Document instance
+     */
+    public static Document createMainDocument(final DigestURL location, final String mimeType, final String charset,
+            final tarParser parser) {
+        final String filename = location.getFileName();
+        final Document maindoc = new Document(location, mimeType, charset, parser, null, null,
+                AbstractParser
+                        .singleList(filename.isEmpty() ? location.toTokens() : MultiProtocolURL.unescape(filename)), // title
+                null, null, null, null, 0.0d, 0.0d, null, null, null, null, false, new Date());
+        return maindoc;
+    }
 
-    public final static boolean isTar(File f) {
+    public static boolean isTar(File f) {
         if (!f.exists() || f.length() < 0x105) return false;
         RandomAccessFile raf = null;
         try {

--- a/source/net/yacy/document/parser/zipParser.java
+++ b/source/net/yacy/document/parser/zipParser.java
@@ -2,21 +2,21 @@
  *  zipParser
  *  Copyright 2010 by Michael Peter Christen, mc@yacy.net, Frankfurt am Main, Germany
  *  First released 29.6.2010 at https://yacy.net
- *
+ * <p>
  * $LastChangedDate$
  * $LastChangedRevision$
  * $LastChangedBy$
- *
+ * <p>
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
  *  License as published by the Free Software Foundation; either
  *  version 2.1 of the License, or (at your option) any later version.
- *
+ * <p>
  *  This library is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  *  Lesser General Public License for more details.
- *
+ * <p>
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program in the file lgpl21.txt
  *  If not, see <http://www.gnu.org/licenses/>.
@@ -123,7 +123,7 @@ public class zipParser extends AbstractParser implements Parser {
                     FileUtils.copy(zis, tmp, entry.getSize());
                     final DigestURL virtualURL = DigestURL.newURL(location, "#" + name);
                     //this.log.logInfo("ZIP file parser: " + virtualURL.toNormalform(false, false));
-                    final Document[] docs = TextParser.parseSource(virtualURL, mime, null, defaultValency, valencySwitchTagNames, scraper, timezoneOffset, 999, tmp);
+                    final Document[] docs = TextParser.parseSource(virtualURL, mime, null, defaultValency, valencySwitchTagNames, scraper, timezoneOffset, 999, tmp, null);
                     if (docs == null) continue;
                     maindoc.addSubDocuments(docs);
                 } catch (final Parser.Failure e) {

--- a/source/net/yacy/repository/LoaderDispatcher.java
+++ b/source/net/yacy/repository/LoaderDispatcher.java
@@ -196,7 +196,7 @@ public final class LoaderDispatcher {
     /**
      * load a resource from the web, from ftp, from smb or a file
      * @param request the request essentials
-     * @param cacheStratgy strategy according to NOCACHE, IFFRESH, IFEXIST, CACHEONLY
+     * @param cacheStrategy strategy according to NOCACHE, IFFRESH, IFEXIST, CACHEONLY
      * @return the loaded entity in a Response object
      * @throws IOException
      */
@@ -351,7 +351,7 @@ public final class LoaderDispatcher {
     /**
      * Open an InputStream on a resource from the web, from ftp, from smb or a file
      * @param request the request essentials
-     * @param cacheStratgy strategy according to NOCACHE, IFFRESH, IFEXIST, CACHEONLY
+     * @param cacheStrategy strategy according to NOCACHE, IFFRESH, IFEXIST, CACHEONLY
      * @return an open ImageInputStream. Don't forget to close it once used!
      * @throws IOException when url is malformed, blacklisted, or CacheStrategy is CACHEONLY and content is unavailable
      */
@@ -468,7 +468,8 @@ public final class LoaderDispatcher {
      * load the url as byte[] content from the web or the cache
      * @param request
      * @param cacheStrategy
-     * @param timeout
+     * @param blacklistType
+     * @param agent
      * @return the content as {@link byte[]}
      * @throws IOException
      */
@@ -672,7 +673,7 @@ public final class LoaderDispatcher {
 
         // parse resource
         try {
-            final Document[] documents = streamResponse.parseWithLimits(maxLinks, maxBytes);
+            final Document[] documents = streamResponse.parseWithLimits(maxLinks, maxBytes, response.lastModified());
             final Document merged = Document.mergeDocuments(location, response.getMimeType(), documents);
 
             final String x_robots_tag = response.getResponseHeader().getXRobotsTag();
@@ -718,7 +719,8 @@ public final class LoaderDispatcher {
                     response.profile().scraper(),
                     timezoneOffset,
                     response.depth(),
-                    response.getContent());
+                    response.getContent(),
+                    null);
             if (documents == null) throw new IOException("document == null");
         } catch (final Exception e) {
             throw new IOException("parser error: " + e.getMessage());

--- a/source/net/yacy/search/Switchboard.java
+++ b/source/net/yacy/search/Switchboard.java
@@ -239,7 +239,10 @@ import net.yacy.utils.crypt;
 import net.yacy.utils.upnp.UPnP;
 import net.yacy.visualization.CircleTool;
 
-
+import java.io.*;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.zip.*;
 
 public final class Switchboard extends serverSwitch {
 
@@ -3005,7 +3008,8 @@ public final class Switchboard extends serverSwitch {
                             response.profile().scraper(),
                             response.profile().timezoneOffset(),
                             response.depth(),
-                            response.getContent());
+                            response.getContent(),
+                            response.lastModified());
                 } else {
                     this.log.warn("Resource '" + response.url().toNormalform(true) + "' is not supported. " + supportError);
                     // create a new errorURL DB entry
@@ -3024,7 +3028,8 @@ public final class Switchboard extends serverSwitch {
                                 response.profile().scraper(),
                                 response.profile().timezoneOffset(),
                                 response.depth(),
-                                response.getContent());
+                                response.getContent(),
+                                response.lastModified());
             }
             if ( documents == null ) {
                 throw new Parser.Failure("Parser returned null.", response.url());

--- a/source/net/yacy/search/index/DocumentIndex.java
+++ b/source/net/yacy/search/index/DocumentIndex.java
@@ -164,7 +164,7 @@ public class DocumentIndex extends Segment {
         InputStream sourceStream = null;
         try {
             sourceStream = url.getInputStream(ClientIdentification.yacyInternetCrawlerAgent);
-            documents = TextParser.parseSource(url, null, null, TagValency.EVAL, new HashSet<String>(), new VocabularyScraper(), timezoneOffset, 0, length, sourceStream);
+            documents = TextParser.parseSource(url, null, null, TagValency.EVAL, new HashSet<String>(), new VocabularyScraper(), timezoneOffset, 0, length, sourceStream, null);
         } catch (final Exception e ) {
             throw new IOException("cannot parse " + url.toNormalform(false) + ": " + e.getMessage());
         } finally {

--- a/test/java/net/yacy/document/parser/GenericXMLParserTest.java
+++ b/test/java/net/yacy/document/parser/GenericXMLParserTest.java
@@ -386,7 +386,8 @@ public class GenericXMLParserTest {
 		final String charsetFromHttpHeader = HeaderFramework.getCharacterEncoding(contentTypeHeader);
 		final DigestURL location = new DigestURL("http://localhost/testfile.xml");
 		try {
-			final Document[] documents = this.parser.parseWithLimits(location, contentTypeHeader, charsetFromHttpHeader, new VocabularyScraper(), 0, inStream, Integer.MAX_VALUE, Long.MAX_VALUE);
+			final Document[] documents = this.parser.parseWithLimits(location, contentTypeHeader, charsetFromHttpHeader,
+					new VocabularyScraper(), 0, inStream, Integer.MAX_VALUE, Long.MAX_VALUE, null);
 			assertEquals(1, documents.length);
 			assertFalse(documents[0].isPartiallyParsed());
 
@@ -407,7 +408,7 @@ public class GenericXMLParserTest {
 		inStream = new ByteArrayInputStream(xhtml.getBytes(StandardCharsets.UTF_8.name()));
 		try {
 			final Document[] documents = this.parser.parseWithLimits(location, contentTypeHeader, charsetFromHttpHeader,
-					new VocabularyScraper(), 0, inStream, 2, Long.MAX_VALUE);
+					new VocabularyScraper(), 0, inStream, 2, Long.MAX_VALUE, null);
 			assertEquals(1, documents.length);
 			assertTrue(documents[0].isPartiallyParsed());
 
@@ -447,7 +448,8 @@ public class GenericXMLParserTest {
 			.append("</body></html>");
 		inStream = new ByteArrayInputStream(xhtmlBuilder.toString().getBytes(StandardCharsets.UTF_8.name()));
 		try {
-			final Document[] documents = this.parser.parseWithLimits(location, contentTypeHeader, charsetFromHttpHeader, new VocabularyScraper(), 0, inStream, Integer.MAX_VALUE, firstBytes);
+			final Document[] documents = this.parser.parseWithLimits(location, contentTypeHeader, charsetFromHttpHeader,
+					new VocabularyScraper(), 0, inStream, Integer.MAX_VALUE, firstBytes, null);
 			assertEquals(1, documents.length);
 			assertTrue(documents[0].isPartiallyParsed());
 

--- a/test/java/net/yacy/document/parser/XZParserTest.java
+++ b/test/java/net/yacy/document/parser/XZParserTest.java
@@ -141,7 +141,7 @@ public class XZParserTest {
 			final DigestURL location = new DigestURL("http://localhost/" + fileName);
 			try (final FileInputStream inStream = new FileInputStream(new File(TEST_FOLER, fileName));) {
 				final Document[] documents = parser.parseWithLimits(location, "application/x-xz",
-						StandardCharsets.UTF_8.name(), new VocabularyScraper(), 0, inStream, 10000, 10000);
+						StandardCharsets.UTF_8.name(), new VocabularyScraper(), 0, inStream, 10000, 10000, null);
 				assertNotNull("Parser result must not be null for file " + fileName, documents);
 				assertNotNull("Parsed text must not be empty for file " + fileName, documents[0].getTextString());
 				assertTrue("Parsed text must contain test word with umlaut char" + fileName,
@@ -175,7 +175,7 @@ public class XZParserTest {
 			final DigestURL location = new DigestURL("http://localhost/" + fileName);
 			try (final FileInputStream inStream = new FileInputStream(new File(TEST_FOLER, fileName));) {
 				final Document[] documents = parser.parseWithLimits(location, "application/x-xz",
-						StandardCharsets.UTF_8.name(), new VocabularyScraper(), 0, inStream, 0, Long.MAX_VALUE);
+						StandardCharsets.UTF_8.name(), new VocabularyScraper(), 0, inStream, 0, Long.MAX_VALUE, null);
 				assertNotNull("Parser result must not be null for file " + fileName, documents);
 				assertNotNull("Parsed text must not be empty for file " + fileName, documents[0].getTextString());
 				assertTrue("Parsed text must contain test word with umlaut char" + fileName,
@@ -211,7 +211,7 @@ public class XZParserTest {
 			 */
 			final long maxBytes = 258;
 			final Document[] documents = parser.parseWithLimits(location, "application/x-xz",
-					StandardCharsets.UTF_8.name(), new VocabularyScraper(), 0, inStream, Integer.MAX_VALUE, maxBytes);
+					StandardCharsets.UTF_8.name(), new VocabularyScraper(), 0, inStream, Integer.MAX_VALUE, maxBytes, null);
 			assertNotNull("Parser result must not be null for file " + fileName, documents);
 			assertNotNull("Parsed text must not be empty for file " + fileName, documents[0].getTextString());
 			assertTrue("Parsed text must contain test word with umlaut char" + fileName,
@@ -231,7 +231,7 @@ public class XZParserTest {
 			 */
 			final long maxBytes = 65;
 			final Document[] documents = parser.parseWithLimits(location, "application/x-xz",
-					StandardCharsets.UTF_8.name(), new VocabularyScraper(), 0, inStream, Integer.MAX_VALUE, maxBytes);
+					StandardCharsets.UTF_8.name(), new VocabularyScraper(), 0, inStream, Integer.MAX_VALUE, maxBytes, null);
 			assertNotNull("Parser result must not be null for file " + fileName, documents);
 			assertNotNull("Parsed text must not be empty for file " + fileName, documents[0].getTextString());
 			assertTrue("Parsed text must contain test word with umlaut char" + fileName,

--- a/test/java/net/yacy/document/parser/bzipParserTest.java
+++ b/test/java/net/yacy/document/parser/bzipParserTest.java
@@ -149,7 +149,7 @@ public class bzipParserTest {
 			try (final FileInputStream inStream = new FileInputStream(new File(TEST_FOLER, fileName));) {
 				final Document[] documents = parser.parseWithLimits(location, "application/x-bzip2",
 						StandardCharsets.UTF_8.name(), new VocabularyScraper(), 0, inStream, 10000,
-						10000);
+						10000, null);
 				assertNotNull("Parser result must not be null for file " + fileName, documents);
 				assertNotNull("Parsed text must not be empty for file " + fileName, documents[0].getTextString());
 				assertTrue("Parsed text must contain test word with umlaut char" + fileName,
@@ -185,7 +185,7 @@ public class bzipParserTest {
 			final DigestURL location = new DigestURL("http://localhost/" + fileName);
 			try (final FileInputStream inStream = new FileInputStream(new File(TEST_FOLER, fileName));) {
 				final Document[] documents = parser.parseWithLimits(location, "application/x-bzip2",
-						StandardCharsets.UTF_8.name(), new VocabularyScraper(), 0, inStream, 0, Long.MAX_VALUE);
+						StandardCharsets.UTF_8.name(), new VocabularyScraper(), 0, inStream, 0, Long.MAX_VALUE, null);
 				assertNotNull("Parser result must not be null for file " + fileName, documents);
 				assertNotNull("Parsed text must not be empty for file " + fileName, documents[0].getTextString());
 				assertTrue("Parsed text must contain test word with umlaut char" + fileName,
@@ -220,7 +220,7 @@ public class bzipParserTest {
 			/* The bytes limit is set to let parsing the beginning text part, but stop before reaching the <a> tag */
 			final long maxBytes = 258;
 			final Document[] documents = parser.parseWithLimits(location, "application/x-bzip2", StandardCharsets.UTF_8.name(),
-					new VocabularyScraper(), 0, inStream, Integer.MAX_VALUE, maxBytes);
+					new VocabularyScraper(), 0, inStream, Integer.MAX_VALUE, maxBytes, null);
 			assertNotNull("Parser result must not be null for file " + fileName, documents);
 			assertNotNull("Parsed text must not be empty for file " + fileName, documents[0].getTextString());
 			assertTrue("Parsed text must contain test word with umlaut char" + fileName,
@@ -237,7 +237,7 @@ public class bzipParserTest {
 			/* The bytes limit is set to let parsing the beginning of the text, but stop before reaching the URL */
 			final long maxBytes = 65;
 			final Document[] documents = parser.parseWithLimits(location, "application/x-bzip2", StandardCharsets.UTF_8.name(),
-					new VocabularyScraper(), 0, inStream, Integer.MAX_VALUE, maxBytes);
+					new VocabularyScraper(), 0, inStream, Integer.MAX_VALUE, maxBytes, null);
 			assertNotNull("Parser result must not be null for file " + fileName, documents);
 			assertNotNull("Parsed text must not be empty for file " + fileName, documents[0].getTextString());
 			assertTrue("Parsed text must contain test word with umlaut char" + fileName,

--- a/test/java/net/yacy/document/parser/gzipParserTest.java
+++ b/test/java/net/yacy/document/parser/gzipParserTest.java
@@ -155,7 +155,7 @@ public class gzipParserTest {
 			try {
 				Document[] documents = parser.parseWithLimits(location, "application/gzip",
 						StandardCharsets.UTF_8.name(), new VocabularyScraper(), 0, inStream, 10000,
-						10000);
+						10000, null);
 				assertNotNull("Parser result must not be null for file " + fileName, documents);
 				assertNotNull("Parsed text must not be empty for file " + fileName, documents[0].getTextString());
 				assertTrue("Parsed text must contain test word with umlaut char" + fileName,
@@ -195,7 +195,7 @@ public class gzipParserTest {
 			DigestURL location = new DigestURL("http://localhost/" + fileName);
 			try {
 				Document[] documents = parser.parseWithLimits(location, "application/gzip",
-						StandardCharsets.UTF_8.name(), new VocabularyScraper(), 0, inStream, 0, Long.MAX_VALUE);
+						StandardCharsets.UTF_8.name(), new VocabularyScraper(), 0, inStream, 0, Long.MAX_VALUE, null);
 				assertNotNull("Parser result must not be null for file " + fileName, documents);
 				assertNotNull("Parsed text must not be empty for file " + fileName, documents[0].getTextString());
 				assertTrue("Parsed text must contain test word with umlaut char" + fileName,
@@ -233,7 +233,7 @@ public class gzipParserTest {
 			/* The bytes limit is set to let parsing the beginning text part, but stop before reaching the <a> tag */
 			final long maxBytes = 258;
 			Document[] documents = parser.parseWithLimits(location, "application/gzip", StandardCharsets.UTF_8.name(),
-					new VocabularyScraper(), 0, inStream, Integer.MAX_VALUE, maxBytes);
+					new VocabularyScraper(), 0, inStream, Integer.MAX_VALUE, maxBytes, null);
 			assertNotNull("Parser result must not be null for file " + fileName, documents);
 			assertNotNull("Parsed text must not be empty for file " + fileName, documents[0].getTextString());
 			assertTrue("Parsed text must contain test word with umlaut char" + fileName,
@@ -253,7 +253,7 @@ public class gzipParserTest {
 			/* The bytes limit is set to let parsing the beginning of the text, but stop before reaching the URL */
 			final long maxBytes = 65;
 			Document[] documents = parser.parseWithLimits(location, "application/gzip", StandardCharsets.UTF_8.name(),
-					new VocabularyScraper(), 0, inStream, Integer.MAX_VALUE, maxBytes);
+					new VocabularyScraper(), 0, inStream, Integer.MAX_VALUE, maxBytes, null);
 			assertNotNull("Parser result must not be null for file " + fileName, documents);
 			assertNotNull("Parsed text must not be empty for file " + fileName, documents[0].getTextString());
 			assertTrue("Parsed text must contain test word with umlaut char" + fileName,

--- a/test/java/net/yacy/document/parser/htmlParserTest.java
+++ b/test/java/net/yacy/document/parser/htmlParserTest.java
@@ -267,7 +267,7 @@ public class htmlParserTest extends TestCase {
 
             try (final FileInputStream inStream = new FileInputStream(file);) {
             	
-                final Document[] docs = parser.parseWithLimits(url, mimetype, null, new VocabularyScraper(), 0, inStream, 1000, 10000);
+                final Document[] docs = parser.parseWithLimits(url, mimetype, null, new VocabularyScraper(), 0, inStream, 1000, 10000, null);
                 final Document doc = docs[0];
                 assertNotNull("Parser result must not be null for file " + fileName, docs);
                 final String parsedText = doc.getTextString();
@@ -305,7 +305,7 @@ public class htmlParserTest extends TestCase {
 			try (InputStream sourceStream = new ByteArrayInputStream(
 					testHtml.toString().getBytes(StandardCharsets.UTF_8));) {
 				final Document[] docs = parser.parseWithLimits(url, mimetype, charset, new VocabularyScraper(), 0,
-						sourceStream, maxLinks, Long.MAX_VALUE);
+						sourceStream, maxLinks, Long.MAX_VALUE, null);
 				final Document doc = docs[0];
 				assertEquals(maxLinks, doc.getAnchors().size());
 				assertEquals("The parsed document should be marked as partially parsed only when the limit is exceeded",
@@ -344,7 +344,7 @@ public class htmlParserTest extends TestCase {
 			try (InputStream sourceStream = new ByteArrayInputStream(
 					testHtml.toString().getBytes(StandardCharsets.UTF_8));) {
 				final Document[] docs = parser.parseWithLimits(url, mimetype, charset, new VocabularyScraper(), 0,
-						sourceStream, maxLinks, Long.MAX_VALUE);
+						sourceStream, maxLinks, Long.MAX_VALUE, null);
 				final Document doc = docs[0];
 				assertEquals(maxLinks, doc.getRSS().size());
 				assertEquals("The parsed document should be marked as partially parsed only when the limit is exceeded",

--- a/test/java/net/yacy/document/parser/tarParserTest.java
+++ b/test/java/net/yacy/document/parser/tarParserTest.java
@@ -126,7 +126,7 @@ public class tarParserTest {
 			/* Content within limits */
 			try {
 				Document[] documents = this.parser.parseWithLimits(location, "application/tar", null,
-						new VocabularyScraper(), 0, inStream, Integer.MAX_VALUE, Long.MAX_VALUE);
+						new VocabularyScraper(), 0, inStream, Integer.MAX_VALUE, Long.MAX_VALUE, null);
 				assertNotNull("Parser result must not be null for file " + fileName, documents);
 
 				final String parsedText = documents[0].getTextString();
@@ -169,7 +169,7 @@ public class tarParserTest {
 			/* Links limit exceeded from the third included file */
 			try {
 				Document[] documents = this.parser.parseWithLimits(location, "application/tar", null,
-						new VocabularyScraper(), 0, inStream, 2, Long.MAX_VALUE);
+						new VocabularyScraper(), 0, inStream, 2, Long.MAX_VALUE, null);
 				assertNotNull("Parser result must not be null for file " + fileName, documents);
 
 				final String parsedText = documents[0].getTextString();
@@ -224,7 +224,7 @@ public class tarParserTest {
 			}
 			try {
 				Document[] documents = this.parser.parseWithLimits(location, "application/tar", null,
-						new VocabularyScraper(), 0, inStream, Integer.MAX_VALUE, maxBytes);
+						new VocabularyScraper(), 0, inStream, Integer.MAX_VALUE, maxBytes, null);
 				assertNotNull("Parser result must not be null for file " + fileName, documents);
 
 				final String parsedText = documents[0].getTextString();


### PR DESCRIPTION
Support for /date search to be sorted by date published - https://github.com/yacy/yacy_search_server/issues/622

The set of rules for extracting date to fill last_modified in ContentScraperDateUtil.java have been carefully selected and tested by @okybaca. 

The getDate() method in ContentScraper.java has a new parameter Date lastModified due to passing the value of last_modified value from the HTTP header at the time of extracting it. That's why there are so many files are affected. The most of the calls pass null, just to fulfil the contract. It is used only in parseDocument() method in Switchboard.java when response has the lastModified HTTP header value. It can be applied later as one of the last use cases in the set of rules for extracting date to fill last_modified in getDate() method in ContentScraperDateUtil.java.