### PR TITLE
Fix critical queue shift bug: allow GLOBAL->LOCAL URL shifting

### DIFF
--- a/source/net/yacy/crawler/HostBalancer.java
+++ b/source/net/yacy/crawler/HostBalancer.java
@@ -285,7 +285,7 @@ public class HostBalancer implements Balancer {
     @Override
     public String push(final Request entry, final CrawlProfile profile, final RobotsTxt robots) throws IOException, SpaceExceededException {
         // Check only in THIS balancer instance, not in global depthCache
-        // This allows shifting URLs between different balancer instances (REMOTE->LOCAL)
+        // This allows shifting URLs between different balancer instances (GLOBAL->LOCAL)
         final String hosthash = entry.url().hosthash();
         final HostQueue existingQueue = this.queues.get(hosthash);
         if (existingQueue != null && existingQueue.has(entry.url().hash())) {


### PR DESCRIPTION
When URLs need to shift between queue instances (e.g., from GLOBAL to LOCAL queue), the previous code checked the global depthCache and rejected the URL as 'double occurrence'. This prevented CrawlQueues.shift() from moving URLs, causing them to get stuck. Fix critical host queue shift bug: allow URL migration between queue instances

Problem:
URLs being shifted between different queue instances (e.g., GLOBAL->LOCAL) were silently lost due to the global depthCache check in HostBalancer.push().

When CrawlQueues.shift() attempted to move URLs between queue instances:
1. URL was removed from source queue instance via pop()
2. URL was pushed to destination queue instance via push()
3. push() checked global static depthCache (shared across ALL instances)
4. depthCache still contained the URL (it WAS in source queue)
5. Push returned 'double occurrence' and rejected the URL
6. Result: URL lost - removed from source, rejected by destination

Root Cause:
HostBalancer.depthCache is a static field shared across all queue instances (LOCAL, GLOBAL/LIMIT, REMOTE, NOLOAD). The push() method checked this global cache before instance-specific queues, preventing valid queue migrations.

Solution: Check only in the current HostBalancer instance (this.queues) instead of checking the global depthCache. This allows URLs to migrate between different queue instances while still preventing duplicate entries within the same queue instance.

This fix ensures automatic queue balancing works correctly without losing URLs.