### PR TITLE
Fix issue #749: Handle special characters in search queries safely

### DIFF
--- a/source/net/yacy/search/query/QueryGoal.java
+++ b/source/net/yacy/search/query/QueryGoal.java
@@ -186,20 +186,29 @@ public class QueryGoal {
                 if (p < s.length() && s.charAt(p) == stop) p++;
             }
 
-            String string;
-            if (stop == space) {
-                string = s.substring(0, p);
-            } else {
-                string = s.substring(0, p - 1);  // Exclude the closing quote
-            }
-            s = p < s.length() ? s.substring(p) : "";
-            p++; // go behind the stop character (eats up space, sq and dq)
-            if (string.length() > 0) {
-                if (inc) {
-                    if (!include_string.contains(string)) include_string.add(string);
-                } else {
-                    if (!exclude_string.contains(string)) exclude_string.add(string);
+            // extract token safely
+            String string = "";
+            
+            if (p > 0) {
+                if (stop == space) {
+                    string = s.substring(0, p);
+                } else if (p > 1) {
+                    string = s.substring(0, p - 1); // exclude closing quote
                 }
+            }
+            
+            // advance cursor
+            s = (p < s.length()) ? s.substring(p) : "";
+            
+            // normalize
+            string = string.trim();
+            if (string.length() == 0) continue;
+            
+            // store token
+            if (inc) {
+                if (!include_string.contains(string)) include_string.add(string);
+            } else {
+                if (!exclude_string.contains(string)) exclude_string.add(string);
             }
         }
 


### PR DESCRIPTION
The parseQuery method had a bug that caused StringIndexOutOfBoundsException when searching for queries containing special characters like '&<--'.

The issue occurred due to:
1. Improper index tracking in substring extraction
2. Unsafe string boundary checks
3. Unconditional index increment that could go out of bounds

This fix:
- Safely extracts tokens by checking boundaries (p > 0 and p > 1)
- Differentiates between quoted and unquoted strings properly
- Trims and validates extracted strings
- Uses continue to skip empty tokens
- Prevents StringIndexOutOfBoundsException

 got it from https://github.com/yacy/yacy_search_server/issues/749#issuecomment-3704300431 thx @smokingwheels
Fixes #749