### PR TITLE
fix: wire indexDistribution.minChunkSize and maxChunkSize config to R…

### DIFF
--- a/source/net/yacy/search/Switchboard.java
+++ b/source/net/yacy/search/Switchboard.java
@@ -1046,6 +1046,9 @@ public final class Switchboard extends serverSwitch {
 
         // initializing dht chunk generation
         this.dhtMaxReferenceCount = (int) this.getConfigLong(SwitchboardConstants.INDEX_DIST_CHUNK_SIZE_START, 50);
+        final int dhtMinReferenceCount = (int) this.getConfigLong(SwitchboardConstants.INDEX_DIST_CHUNK_SIZE_MIN, 10);
+        final int dhtMaxReferenceCountLimit = (int) this.getConfigLong(SwitchboardConstants.INDEX_DIST_CHUNK_SIZE_MAX, 1000);
+        this.dhtMaxReferenceCount = Math.max(dhtMinReferenceCount, Math.min(dhtMaxReferenceCountLimit, this.dhtMaxReferenceCount));
 
         // init robinson cluster
         // before we do that, we wait some time until the seed list is loaded.

--- a/test/java/net/yacy/search/SwitchboardConstantsTest.java
+++ b/test/java/net/yacy/search/SwitchboardConstantsTest.java
@@ -1,0 +1,23 @@
+package net.yacy.search;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class SwitchboardConstantsTest {
+
+    @Test
+    public void testMinChunkSizeConstantMatchesConfigKey() {
+        assertEquals("indexDistribution.minChunkSize", SwitchboardConstants.INDEX_DIST_CHUNK_SIZE_MIN);
+    }
+
+    @Test
+    public void testMaxChunkSizeConstantMatchesConfigKey() {
+        assertEquals("indexDistribution.maxChunkSize", SwitchboardConstants.INDEX_DIST_CHUNK_SIZE_MAX);
+    }
+
+    @Test
+    public void testStartChunkSizeConstantMatchesConfigKey() {
+        assertEquals("indexDistribution.startChunkSize", SwitchboardConstants.INDEX_DIST_CHUNK_SIZE_START);
+    }
+}


### PR DESCRIPTION
…WI transfer batch (#724)

INDEX_DIST_CHUNK_SIZE_MIN and _MAX constants were defined but never read. dhtMaxReferenceCount was set only from startChunkSize with no bounds enforcement. Clamp the initial value to [minChunkSize, maxChunkSize] so both config keys actually control the DHT reference count range.