### PR TITLE
fix: auto-trim RWI RAM buffer when heap fraction threshold exceeded (…

### DIFF
--- a/defaults/yacy.init
+++ b/defaults/yacy.init
@@ -1288,6 +1288,9 @@ resource.disk.used.max.overshot=4194304
 
 # minimum memory to accept dht-in (MiB)
 memory.acceptDHTabove = 50
+
+# maximum fraction of max heap that the RWI RAM buffer may occupy before entries are trimmed (0.0-1.0)
+rwi.memory.maxHeapFraction = 0.25
 memory.disabledDHT = false
 
 # wether using standard memory strategy - or try generation memory strategy

--- a/source/net/yacy/search/ResourceObserver.java
+++ b/source/net/yacy/search/ResourceObserver.java
@@ -78,6 +78,25 @@ public class ResourceObserver {
         this.normalizedDiskUsed = getNormalizedDiskUsed(true);
     	this.normalizedMemoryFree = getNormalizedMemoryFree();
 
+        // proactively trim RWI RAM buffer when it exceeds the configured heap fraction
+        final IndexCell<WordReference> termIndexForTrim = this.sb.index.termIndex();
+        if (termIndexForTrim != null) {
+            final float rwiMaxHeapFraction = this.sb.getConfigFloat(
+                SwitchboardConstants.RWI_MAX_HEAP_FRACTION, SwitchboardConstants.RWI_MAX_HEAP_FRACTION_DEFAULT);
+            final long rwiMaxBytes = (long) (Runtime.getRuntime().maxMemory() * rwiMaxHeapFraction);
+            final long rwiCurrentBytes = termIndexForTrim.getBufferSizeBytes();
+            if (rwiCurrentBytes > rwiMaxBytes) {
+                log.warn("RWI RAM buffer (" + (rwiCurrentBytes / 1024 / 1024) + " MB) exceeds heap fraction limit ("
+                    + (rwiMaxBytes / 1024 / 1024) + " MB), trimming oversized reference entries");
+                try {
+                    final int trimmed = termIndexForTrim.deleteOld(100, 5000);
+                    if (trimmed > 0) log.info("RWI trim: shrinked " + trimmed + " reference containers");
+                } catch (final IOException e) {
+                    log.warn("RWI trim failed: " + e.getMessage());
+                }
+            }
+        }
+
     	// take actions if disk space is below AMPLE
         if (this.normalizedDiskFree != Space.AMPLE ||
             this.normalizedDiskUsed != Space.AMPLE ||

--- a/source/net/yacy/search/SwitchboardConstants.java
+++ b/source/net/yacy/search/SwitchboardConstants.java
@@ -574,6 +574,8 @@ public final class SwitchboardConstants {
     public static final long RESOURCE_DISK_USED_MAX_OVERSHOT_DEFAULT    = 1048576L;
 
     public static final String MEMORY_ACCEPTDHT = "memory.acceptDHTabove"; // minimum memory to accept dht-in (MiB)
+    public static final String RWI_MAX_HEAP_FRACTION = "rwi.memory.maxHeapFraction";
+    public static final float RWI_MAX_HEAP_FRACTION_DEFAULT = 0.25f;
     public static final String INDEX_RECEIVE_AUTODISABLED = "memory.disabledDHT"; // set if DHT was disabled by ResourceObserver
     public static final String CRAWLJOB_LOCAL_AUTODISABLED = "memory.disabledLocalCrawler"; // set if local crawl was disabled by ResourceObserver
     public static final String CRAWLJOB_REMOTE_AUTODISABLED = "memory.disabledRemoteCrawler"; // set if remote crawl was disabled by ResourceObserver


### PR DESCRIPTION
…#731)

Add rwi.memory.maxHeapFraction config key (default 0.25) and check it in ResourceObserver.resourceObserverJob(). When the RWI RAM buffer exceeds the configured fraction of max heap, call IndexCell.deleteOld() to shrink oversized reference containers before an OOM can occur.