### PR TITLE
fix: HTML-escape reflected user input and crawled document metadata to prevent XSS (#401, #630) 

### DIFF
--- a/source/net/yacy/htroot/ViewFile.java
+++ b/source/net/yacy/htroot/ViewFile.java
@@ -279,13 +279,14 @@ public class ViewFile {
                 final String content = document.getTextString();
                 // content = wikiCode.replaceHTML(content); // added by Marc Nause
                 prop.put("viewMode", VIEW_MODE_AS_PARSED_TEXT);
-                prop.put("viewMode_title", document.dc_title());
-                prop.put("viewMode_creator", document.dc_creator());
-                prop.put("viewMode_subject", document.dc_subject(','));
-                prop.put("viewMode_description", document.dc_description().length == 0 ? new String[]{""} : document.dc_description());
-                prop.put("viewMode_publisher", document.dc_publisher());
-                prop.put("viewMode_format", document.dc_format());
-                prop.put("viewMode_identifier", document.dc_identifier());
+                prop.putHTML("viewMode_title", document.dc_title());
+                prop.putHTML("viewMode_creator", document.dc_creator());
+                prop.putHTML("viewMode_subject", document.dc_subject(','));
+                final String[] descs = document.dc_description();
+                prop.putHTML("viewMode_description", descs.length == 0 ? "" : String.join("; ", descs));
+                prop.putHTML("viewMode_publisher", document.dc_publisher());
+                prop.putHTML("viewMode_format", document.dc_format());
+                prop.putHTML("viewMode_identifier", document.dc_identifier());
                 prop.put("viewMode_source", url.toNormalform(false));
                 prop.put("viewMode_lat", document.lat());
                 prop.put("viewMode_lon", document.lon());

--- a/source/net/yacy/htroot/yacysearch.java
+++ b/source/net/yacy/htroot/yacysearch.java
@@ -188,7 +188,7 @@ public class yacysearch {
             prop.put("offset", "0");
             prop.put("resource", "global");
             prop.put("urlmaskfilter", (post == null) ? ".*" : post.get("urlmaskfilter", ".*"));
-            prop.put("prefermaskfilter", (post == null) ? "" : post.get("prefermaskfilter", ""));
+            prop.putHTML("prefermaskfilter", (post == null) ? "" : post.get("prefermaskfilter", ""));
             prop.put("indexof", "off");
             prop.put("constraint", "");
             prop.put("depth", "0");


### PR DESCRIPTION
Summary                                                                                                                                                                               
                                                                                                                                                                                        
  - prefermaskfilter was reflected into an HTML attribute (value="#[prefermaskfilter]#") in yacysearch.html using prop.put() in the early-return path (no index / search not allowed),  
  allowing attribute-breaking XSS. The normal search path already used putHTML — the early-return path did not.                                                                         
  - In ViewFile.java's parsed view, seven Dublin Core metadata fields (dc_title, dc_creator, dc_subject, dc_description, dc_publisher, dc_format, dc_identifier) sourced from crawled
  documents were written with prop.put() and rendered unescaped inside HTML <dd> elements. A malicious page with a title like <script>alert(1)</script> would execute in the viewer's   
  browser.        
                                                                                                                                                                                        
  Fix             

  - yacysearch.java: change prop.put("prefermaskfilter", ...) to prop.putHTML() in the early-return path                                                                                
  - ViewFile.java: switch all seven dc_* metadata fields to prop.putHTML(). For dc_description (which returns String[]), join with "; " before escaping
                                                                                                                                                                                        
  Two commits, one per issue:                                                                                                                                                           
  - fix: HTML-escape prefermaskfilter in early-return path to prevent reflected XSS (#401)                                                                                              
  - fix: HTML-escape crawled document metadata in ViewFile parsed view to prevent XSS (#630)