### PR TITLE
feat: add exponential freshness decay boost to post-ranking

### DIFF
--- a/source/net/yacy/search/query/SearchEvent.java
+++ b/source/net/yacy/search/query/SearchEvent.java
@@ -2043,6 +2043,16 @@ public final class SearchEvent implements ScoreMapUpdatesListener {
             if (urlcompmap.contains(queryword)) r += 255 << this.query.ranking.coeff_appurl;
             if (descrcompmap.contains(queryword)) r += 255 << this.query.ranking.coeff_app_dc_title;
         }
+
+        // apply exponential freshness decay boost
+        // a document modified today gets +256, one modified 365 days ago gets +128, 730 days ago +64, etc.
+        final java.util.Date moddate = rentry.moddate();
+        if (moddate != null) {
+            final long ageDays = Math.max(0L, (System.currentTimeMillis() - moddate.getTime()) / 86_400_000L);
+            final double decayFactor = Math.exp(-ageDays / 365.0);
+            r += (long)(256.0 * decayFactor);
+        }
+
         return r;
     }
 


### PR DESCRIPTION
Documents modified recently score higher using exp(-ageDays/365) decay — a page modified today gets +256 points, one modified a year ago gets +128, two years ago +64. Skipped when moddate is unavailable.