### PR TITLE
feat: penalize thin content and link farms in post-ranking

### DIFF
--- a/source/net/yacy/search/query/SearchEvent.java
+++ b/source/net/yacy/search/query/SearchEvent.java
@@ -2043,6 +2043,26 @@ public final class SearchEvent implements ScoreMapUpdatesListener {
             if (urlcompmap.contains(queryword)) r += 255 << this.query.ranking.coeff_appurl;
             if (descrcompmap.contains(queryword)) r += 255 << this.query.ranking.coeff_app_dc_title;
         }
+
+        // thin content penalty: pages with very few words are likely low-quality
+        final int wordCount = rentry.wordCount();
+        if (wordCount < 50) {
+            r += -512;
+        } else if (wordCount < 150) {
+            r += (long)(-512.0 * (150 - wordCount) / 100.0);
+        }
+
+        // link farm penalty: high outbound-to-inbound ratio signals spam
+        final int lother = rentry.lother();
+        if (lother > 50) {
+            final double ratio = (double) lother / (1 + rentry.llocal());
+            if (ratio > 20) {
+                r += -512;
+            } else if (ratio > 5) {
+                r += (long)(-512.0 * (ratio - 5) / 15.0);
+            }
+        }
+
         return r;
     }
 


### PR DESCRIPTION
Two new negative signals in postRanking:
- Thin content: pages with <150 words lose up to -512 points (full penalty below 50 words, linear ramp from 50-150)
- Link farms: pages where outbound links greatly exceed inbound (ratio >5 after a minimum threshold of 50 outbound) lose up to -512 points

Both signals use data already present in the Solr index.