### PR TITLE
fix: scale nodeStack capacity with query offset so late pages aren't …

### DIFF
--- a/source/net/yacy/search/query/SearchEvent.java
+++ b/source/net/yacy/search/query/SearchEvent.java
@@ -354,7 +354,7 @@ public final class SearchEvent implements ScoreMapUpdatesListener {
             this.imagePageCounter = query.offset;
         }
         this.loader = loader;
-        this.nodeStack = new WeakPriorityBlockingQueue<>(max_results_node, false);
+        this.nodeStack = new WeakPriorityBlockingQueue<>(max_results_node + (query != null ? query.offset + query.itemsPerPage() : 0), false);
         this.maxExpectedRemoteReferences = new AtomicInteger(0);
         this.expectedRemoteReferences = new AtomicInteger(0);
         this.excludeintext_image = Switchboard.getSwitchboard().getConfigBool("search.excludeintext.image", true);


### PR DESCRIPTION
…evicted

WeakPriorityBlockingQueue evicts lowest-scoring entries when full. With a fixed 150-slot nodeStack, page 2+ results compete against page 1 results and high-quality late-page candidates get evicted before ranking completes. Adding query.offset + query.itemsPerPage() to the initial capacity ensures enough slots exist for the requested page's candidates to survive.