### PR TITLE
feat: show 'N more from domain.com' link when domain cap hides results

### DIFF
--- a/htroot/yacysearchitem.html
+++ b/htroot/yacysearchitem.html
@@ -54,6 +54,7 @@
   #(showVocabulary)#::<br/>#{vocabulary}##[name]#:#[terms]# #{/vocabulary}##(/showVocabulary)#
   #(showSnapshots)#::<span role="separator" aria-orientation="vertical">&nbsp;|&nbsp;</span><a href="#[link]#" target="_blank">#[extension]# Snapshot</a>#(/showSnapshots)#
   #(showRanking)#::<span role="separator" aria-orientation="vertical">&nbsp;|&nbsp;</span><span title="Raw ranking score value">Ranking: #[ranking]#</span>#(/showRanking)#
+  #(showDomainMore)#::<span role="separator" aria-orientation="vertical">&nbsp;|&nbsp;</span><a href="yacysearch.html?query=#[siteQuery]#" title="#[count]# more results from #[host]# were hidden by domain diversity filter">#[count]# more from #[host]#</a>#(/showDomainMore)#
   </p>
   </div>
   ::

--- a/source/net/yacy/htroot/yacysearchitem.java
+++ b/source/net/yacy/htroot/yacysearchitem.java
@@ -409,7 +409,13 @@ public class yacysearchitem {
             //prop.put("content_ybr", RankingProcess.ybr(result.hash()));
             prop.putHTML("content_size", Integer.toString(result.filesize())); // we don't use putNUM here because that number shall be usable as sorting key. To print the size, use 'sizename'
             prop.putHTML("content_sizename", RSSMessage.sizename(result.filesize()));
-            prop.putHTML("content_host", resultURL.getHost() == null ? "" : resultURL.getHost());
+            final String resultHost = resultURL.getHost() == null ? "" : resultURL.getHost();
+            prop.putHTML("content_host", resultHost);
+            final int domainSkipped = theSearch.getDomainSkippedCount(result.hosthash());
+            prop.put("content_showDomainMore", domainSkipped > 0 ? 1 : 0);
+            prop.put("content_showDomainMore_count", domainSkipped);
+            prop.putHTML("content_showDomainMore_host", resultHost);
+            prop.putUrlEncodedHTML("content_showDomainMore_siteQuery", "site:" + resultHost + (origQ.isEmpty() ? "" : " " + origQ));
             prop.putXML("content_file", resultFileName); // putXML for rss
             prop.putXML("content_path", resultURL.getPath()); // putXML for rss
             prop.put("content_nl", (item == theSearch.query.offset) ? 0 : 1);

--- a/source/net/yacy/search/query/SearchEvent.java
+++ b/source/net/yacy/search/query/SearchEvent.java
@@ -237,6 +237,12 @@ public final class SearchEvent implements ScoreMapUpdatesListener {
     private final boolean disablePostRanking;
     public  final boolean excludeintext_image;
 
+    private static final int MAX_RESULTS_PER_DOMAIN = 2;
+    /** counts emitted results per domain hosthash; null when site: query is active */
+    private final ConcurrentHashMap<String, AtomicInteger> domainResultCount;
+    /** counts results skipped per domain hosthash due to the domain cap */
+    private final ConcurrentHashMap<String, AtomicInteger> domainSkippedCount;
+
     // the following values are filled during the search process as statistics for the search
     // In the next comments "filtering" is doubles checking and applying eventual search query constraints/modifiers
 
@@ -355,6 +361,8 @@ public final class SearchEvent implements ScoreMapUpdatesListener {
         }
         this.loader = loader;
         this.nodeStack = new WeakPriorityBlockingQueue<>(max_results_node, false);
+        this.domainResultCount = new ConcurrentHashMap<>();
+        this.domainSkippedCount = new ConcurrentHashMap<>();
         this.maxExpectedRemoteReferences = new AtomicInteger(0);
         this.expectedRemoteReferences = new AtomicInteger(0);
         this.excludeintext_image = Switchboard.getSwitchboard().getConfigBool("search.excludeintext.image", true);
@@ -2608,13 +2616,31 @@ public final class SearchEvent implements ScoreMapUpdatesListener {
         if (this.urlhashes.has(entry.hash())) {
             return false;
         }
+        // enforce domain cap unless query is for a specific site
+        final boolean checkDomain = this.query == null || this.query.modifier.sitehash == null;
+        AtomicInteger domainCounter = null;
+        if (checkDomain) {
+            final String hosthash = entry.hosthash();
+            domainCounter = this.domainResultCount.computeIfAbsent(hosthash, k -> new AtomicInteger(0));
+            if (domainCounter.get() >= MAX_RESULTS_PER_DOMAIN) {
+                this.domainSkippedCount.computeIfAbsent(hosthash, k -> new AtomicInteger(0)).incrementAndGet();
+                return false;
+            }
+        }
         try {
             this.urlhashes.putUnique(entry.hash());
-            return true;
         } catch (final SpaceExceededException e) {
             ConcurrentLog.logException(e);
             return false;
         }
+        if (domainCounter != null) domainCounter.incrementAndGet();
+        return true;
+    }
+
+    /** Returns the number of results from this domain's hosthash that were hidden by the domain cap. */
+    public int getDomainSkippedCount(final String hosthash) {
+        final AtomicInteger c = this.domainSkippedCount.get(hosthash);
+        return c == null ? 0 : c.get();
     }
 
     private void decrementNodeAvailableCount(final URIMetadataNode entry) {


### PR DESCRIPTION
When the domain diversity cap (MAX_RESULTS_PER_DOMAIN=2) drops results for a domain, SearchEvent now tracks the skipped count per hosthash. Each rendered result exposes this count to the template, which appends a clickable link 'N more from domain.com' that launches a site: search to recover the hidden results. The link only appears when at least one result was hidden.