### PR TITLE
feat: suppress near-duplicate results using fuzzy content signature

### DIFF
--- a/source/net/yacy/kelondro/data/meta/URIMetadataNode.java
+++ b/source/net/yacy/kelondro/data/meta/URIMetadataNode.java
@@ -437,6 +437,14 @@ public class URIMetadataNode extends SolrDocument /* implements Comparable<URIMe
         return getInt(CollectionSchema.wordcount_i);
     }
 
+    /** Returns the fuzzy content signature (64-bit hash of representative words), or 0 if not computed. */
+    public long fuzzySignature() {
+        Object x = this.getFieldValue(CollectionSchema.fuzzy_signature_l.getSolrFieldName());
+        if (x instanceof Long) return (Long) x;
+        if (x instanceof Integer) return ((Integer) x).longValue();
+        return 0L;
+    }
+
     /**
      * in case that images are embedded in the document, get one image which can be used as thumbnail
      * @return the first embedded image url

--- a/source/net/yacy/search/query/SearchEvent.java
+++ b/source/net/yacy/search/query/SearchEvent.java
@@ -218,6 +218,8 @@ public final class SearchEvent implements ScoreMapUpdatesListener {
     private final HandleSet urlhashes;
     /** best known candidate quality per url hash, used to prefer richer duplicates before final emission */
     private final ConcurrentHashMap<String, Integer> bestResultQualityByUrlHash;
+    /** fuzzy content signatures already emitted; used to suppress near-duplicate pages */
+    private final Set<Long> seenFuzzySignatures;
 
     /** a map from tagging vocabulary names to tagging predicate uris */
     private final Map<String, String> taggingPredicates;
@@ -357,6 +359,7 @@ public final class SearchEvent implements ScoreMapUpdatesListener {
         this.nodeStack = new WeakPriorityBlockingQueue<>(max_results_node, false);
         this.maxExpectedRemoteReferences = new AtomicInteger(0);
         this.expectedRemoteReferences = new AtomicInteger(0);
+        this.seenFuzzySignatures = java.util.Collections.newSetFromMap(new ConcurrentHashMap<>());
         this.excludeintext_image = Switchboard.getSwitchboard().getConfigBool("search.excludeintext.image", true);
 
         // prepare configured search navigation
@@ -2608,13 +2611,18 @@ public final class SearchEvent implements ScoreMapUpdatesListener {
         if (this.urlhashes.has(entry.hash())) {
             return false;
         }
+        // suppress near-duplicate content: skip pages whose fuzzy content signature was already emitted
+        final long fuzzySig = entry.fuzzySignature();
+        if (fuzzySig != 0L && !this.seenFuzzySignatures.add(fuzzySig)) {
+            return false;
+        }
         try {
             this.urlhashes.putUnique(entry.hash());
-            return true;
         } catch (final SpaceExceededException e) {
             ConcurrentLog.logException(e);
             return false;
         }
+        return true;
     }
 
     private void decrementNodeAvailableCount(final URIMetadataNode entry) {


### PR DESCRIPTION
YaCy already computes fuzzy_signature_l (a 64-bit hash of the document's representative word frequency profile) for every indexed page. This change tracks which signatures have been emitted in shouldEmitCandidate and skips subsequent pages with the same signature, preventing near-identical content (mirror pages, scraped copies, paginated duplicates) from filling the result set. Pages with signature=0 (not yet computed) pass through unchanged.