### PR TITLE
Improve/rwi host demotion

### DIFF
--- a/htroot/RankingRWI_p.html
+++ b/htroot/RankingRWI_p.html
@@ -75,6 +75,16 @@
         </dl>
       </fieldset>
       <fieldset>
+        <legend>Demoted Hosts</legend>
+        <p>Hosts listed here will have their ranking score divided by 100 (or a custom divisor), pushing them toward the end of results without removing them. Demotion is skipped when the hostname appears in the search query. Enter one hostname per line, with an optional divisor (e.g. <code>example.com 500</code>).</p>
+        <textarea name="demotedHosts" rows="6" cols="60" style="font-family:monospace">#[demotedHosts]#</textarea>
+      </fieldset>
+      <fieldset>
+        <legend>Demoted Words</legend>
+        <p>Results whose URL, title, or description contains any of these words or phrases will have their ranking score divided by 100 (or a custom divisor). Enter one word or quoted phrase per line, with an optional divisor (e.g. <code>"adult services" 500</code>). Note: only applies to results retrieved via the Solr index.</p>
+        <textarea name="demotedWords" rows="6" cols="60" style="font-family:monospace">#[demotedWords]#</textarea>
+      </fieldset>
+      <fieldset>
         <input type="submit" name="EnterRanking" class="btn btn-primary" value="Set as Default Ranking" />
         <input type="submit" name="ResetRanking" class="btn btn-primary" value="Re-Set to Built-In Ranking" />
       </fieldset>

--- a/source/net/yacy/htroot/RankingRWI_p.java
+++ b/source/net/yacy/htroot/RankingRWI_p.java
@@ -30,6 +30,7 @@ package net.yacy.htroot;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.StringJoiner;
 
 import net.yacy.cora.document.analysis.Classification;
 import net.yacy.cora.protocol.RequestHeader;
@@ -99,6 +100,8 @@ public class RankingRWI_p {
         prop.put("urlmaskoptions", "0");
         prop.putHTML("urlmaskoptions_urlmaskfilter", ".*");
         prop.put("jumpToCursor", "1");
+        prop.put("demotedHosts", "");
+        prop.put("demotedWords", "");
         return prop;
     }
 
@@ -142,6 +145,15 @@ public class RankingRWI_p {
         }
     }
 
+    private static String normalizeDemotedHosts(final String raw) {
+        final StringJoiner sj = new StringJoiner("\n");
+        for (final String line : raw.split("[\\r\\n]+")) {
+            final String host = line.trim().toLowerCase(java.util.Locale.ROOT);
+            if (!host.isEmpty()) sj.add(host);
+        }
+        return sj.toString();
+    }
+
     public static serverObjects respond(@SuppressWarnings("unused") final RequestHeader header, final serverObjects post, final serverSwitch env) {
         final Switchboard sb = (Switchboard) env;
 
@@ -154,7 +166,11 @@ public class RankingRWI_p {
             final serverObjects prop = defaultValues();
             final RankingProfile ranking;
             if (sb == null) ranking = new RankingProfile(Classification.ContentDomain.TEXT);
-            else ranking = sb.getRanking();
+            else {
+                ranking = sb.getRanking();
+                prop.putHTML("demotedHosts", sb.getConfig(SwitchboardConstants.SEARCH_RANKING_RWI_DEMOTED_HOSTS, ""));
+                prop.putHTML("demotedWords", sb.getConfig(SwitchboardConstants.SEARCH_RANKING_RWI_DEMOTED_WORDS, ""));
+            }
             putRanking(prop, ranking, "local");
             return prop;
         }
@@ -162,17 +178,23 @@ public class RankingRWI_p {
         if (post.containsKey("EnterRanking")) {
             final RankingProfile ranking = new RankingProfile("local", post.toString());
             sb.setConfig(SwitchboardConstants.SEARCH_RANKING_RWI_PROFILE, crypt.simpleEncode(ranking.toExternalString()));
+            final String demotedHosts = normalizeDemotedHosts(post.get("demotedHosts", ""));
+            sb.setConfig(SwitchboardConstants.SEARCH_RANKING_RWI_DEMOTED_HOSTS, demotedHosts);
+            final String demotedWords = normalizeDemotedHosts(post.get("demotedWords", ""));
+            sb.setConfig(SwitchboardConstants.SEARCH_RANKING_RWI_DEMOTED_WORDS, demotedWords);
             final serverObjects prop = defaultValues();
-            //prop.putAll(ranking.toExternalMap("local"));
             putRanking(prop, ranking, "local");
+            prop.putHTML("demotedHosts", demotedHosts);
+            prop.putHTML("demotedWords", demotedWords);
             return prop;
         }
 
         if (post.containsKey("ResetRanking")) {
             sb.setConfig(SwitchboardConstants.SEARCH_RANKING_RWI_PROFILE, "");
+            sb.setConfig(SwitchboardConstants.SEARCH_RANKING_RWI_DEMOTED_HOSTS, "");
+            sb.setConfig(SwitchboardConstants.SEARCH_RANKING_RWI_DEMOTED_WORDS, "");
             final RankingProfile ranking = new RankingProfile(Classification.ContentDomain.TEXT);
             final serverObjects prop = defaultValues();
-            //prop.putAll(ranking.toExternalMap("local"));
             putRanking(prop, ranking, "local");
             return prop;
         }
@@ -181,6 +203,8 @@ public class RankingRWI_p {
         final serverObjects prop = new serverObjects();
         putRanking(prop, localRanking, "local");
         prop.putAll(localRanking.toExternalMap("local"));
+        prop.putHTML("demotedHosts", sb.getConfig(SwitchboardConstants.SEARCH_RANKING_RWI_DEMOTED_HOSTS, ""));
+        prop.putHTML("demotedWords", sb.getConfig(SwitchboardConstants.SEARCH_RANKING_RWI_DEMOTED_WORDS, ""));
 
         return prop;
     }

--- a/source/net/yacy/kelondro/data/meta/URIMetadataNode.java
+++ b/source/net/yacy/kelondro/data/meta/URIMetadataNode.java
@@ -437,6 +437,14 @@ public class URIMetadataNode extends SolrDocument /* implements Comparable<URIMe
         return getInt(CollectionSchema.wordcount_i);
     }
 
+    /** Returns the fuzzy content signature (64-bit hash of representative words), or 0 if not computed. */
+    public long fuzzySignature() {
+        Object x = this.getFieldValue(CollectionSchema.fuzzy_signature_l.getSolrFieldName());
+        if (x instanceof Long) return (Long) x;
+        if (x instanceof Integer) return ((Integer) x).longValue();
+        return 0L;
+    }
+
     /**
      * in case that images are embedded in the document, get one image which can be used as thumbnail
      * @return the first embedded image url

--- a/source/net/yacy/search/SwitchboardConstants.java
+++ b/source/net/yacy/search/SwitchboardConstants.java
@@ -700,6 +700,8 @@ public final class SwitchboardConstants {
      * ranking+evaluation
      */
     public static final String SEARCH_RANKING_RWI_PROFILE = "search.ranking.rwi.profile"; // old rwi rankingProfile ranking
+    public static final String SEARCH_RANKING_RWI_DEMOTED_HOSTS = "search.ranking.rwi.demotedhosts"; // newline-separated list of hostnames to demote in RWI results
+    public static final String SEARCH_RANKING_RWI_DEMOTED_WORDS = "search.ranking.rwi.demotedwords"; // newline-separated list of words that demote results whose URL or title contains them
     public static final String SEARCH_RANKING_SOLR_DOUBLEDETECTION_MINLENGTH = "search.ranking.solr.doubledetection.minlength";
     public static final String SEARCH_RANKING_SOLR_DOUBLEDETECTION_QUANTRATE = "search.ranking.solr.doubledetection.quantrate";
 

--- a/source/net/yacy/search/query/SearchEvent.java
+++ b/source/net/yacy/search/query/SearchEvent.java
@@ -29,9 +29,11 @@ package net.yacy.search.query;
 import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.ConcurrentModificationException;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -443,7 +445,8 @@ public final class SearchEvent implements ScoreMapUpdatesListener {
         this.addRunning = true;
         this.disablePostRanking = this.query.isLocal();
         this.receivedRemoteReferences = new AtomicInteger(0);
-        this.order = new ReferenceOrder(this.query.ranking, this.query.targetlang);
+        final String queryString = this.query.getQueryGoal().getQueryString(false);
+        this.order = new ReferenceOrder(this.query.ranking, this.query.targetlang, loadDemotedHostHashes(queryString), loadDemotedWords());
         this.urlhashes = new RowHandleSet(Word.commonHashLength, Word.commonHashOrder, 100);
         this.bestResultQualityByUrlHash = new ConcurrentHashMap<>();
         this.taggingPredicates = new HashMap<>();
@@ -1117,6 +1120,9 @@ public final class SearchEvent implements ScoreMapUpdatesListener {
                             score = (long) ((1000000.0f * scorex) - iEntry.urllength()); // we modify the score here since the solr score is equal in many cases and then the order would simply depend on the url hash which would be silly
                         else
                             score = this.order.cardinal(iEntry);
+                        final long hostDiv = this.order.getDemotionDivisor(iEntry.hosthash());
+                        if (hostDiv > 1L) score /= hostDiv;
+                        else { final long wordDiv = this.order.getDemotionDivisorByWords(iEntry.url().toNormalform(true), iEntry.dc_title(), String.join(" ", iEntry.getDescription())); if (wordDiv > 1L) score /= wordDiv; }
                         this.nodeStack.put(new ReverseElement<>(iEntry, score)); // inserts the element and removes the worst (which is smallest)
                         break rankingtryloop;
                     } catch (final ArithmeticException e ) {
@@ -2471,6 +2477,62 @@ public final class SearchEvent implements ScoreMapUpdatesListener {
 
     public ReferenceOrder getOrder() {
         return this.order;
+    }
+
+    private static Map<String, Long> loadDemotedWords() {
+        final Switchboard sb = Switchboard.getSwitchboard();
+        if (sb == null) return Collections.emptyMap();
+        final String raw = sb.getConfig(SwitchboardConstants.SEARCH_RANKING_RWI_DEMOTED_WORDS, "").trim();
+        if (raw.isEmpty()) return Collections.emptyMap();
+        final Map<String, Long> words = new HashMap<>();
+        for (final String line : raw.split("[\\r\\n]+")) {
+            String entry = line.trim().toLowerCase(java.util.Locale.ROOT);
+            if (entry.isEmpty()) continue;
+            final long divisor = parseTrailingDivisor(entry);
+            if (divisor > 0) entry = entry.substring(0, entry.lastIndexOf(' ')).trim();
+            if (entry.startsWith("\"") && entry.endsWith("\"") && entry.length() > 2) entry = entry.substring(1, entry.length() - 1).trim();
+            if (!entry.isEmpty()) words.put(entry, divisor > 0 ? divisor : 100L);
+        }
+        return words;
+    }
+
+    private static long parseTrailingDivisor(final String entry) {
+        final int lastSpace = entry.lastIndexOf(' ');
+        if (lastSpace < 1) return 0L;
+        try {
+            final long d = Long.parseLong(entry.substring(lastSpace + 1));
+            return d > 1 ? d : 0L;
+        } catch (final NumberFormatException ignored) { return 0L; }
+    }
+
+    private static Map<String, Long> loadDemotedHostHashes(final String queryString) {
+        final Switchboard sb = Switchboard.getSwitchboard();
+        if (sb == null) return Collections.emptyMap();
+        final String raw = sb.getConfig(SwitchboardConstants.SEARCH_RANKING_RWI_DEMOTED_HOSTS, "").trim();
+        if (raw.isEmpty()) return Collections.emptyMap();
+        final String queryLower = queryString == null ? "" : queryString.toLowerCase(java.util.Locale.ROOT);
+        final Map<String, Long> hashes = new HashMap<>();
+        for (final String line : raw.split("[\\r\\n]+")) {
+            String entry = line.trim().toLowerCase(java.util.Locale.ROOT);
+            if (entry.isEmpty()) continue;
+            final long divisor = parseTrailingDivisor(entry);
+            if (divisor > 0) entry = entry.substring(0, entry.lastIndexOf(' ')).trim();
+            if (entry.isEmpty()) continue;
+            // skip demotion if any part of the hostname appears in the query
+            if (!queryLower.isEmpty()) {
+                boolean queryMatchesHost = false;
+                for (final String label : entry.split("\\.")) {
+                    if (label.length() > 2 && queryLower.contains(label)) { queryMatchesHost = true; break; }
+                }
+                if (queryMatchesHost) continue;
+            }
+            final long d = divisor > 0 ? divisor : 100L;
+            try {
+                hashes.put(net.yacy.cora.document.id.DigestURL.hosthash(entry, 80), d);
+                hashes.put(net.yacy.cora.document.id.DigestURL.hosthash(entry, 443), d);
+            } catch (final java.net.MalformedURLException ignored) {}
+        }
+        return hashes;
     }
 
     /**

--- a/source/net/yacy/search/query/SearchEvent.java
+++ b/source/net/yacy/search/query/SearchEvent.java
@@ -218,6 +218,8 @@ public final class SearchEvent implements ScoreMapUpdatesListener {
     private final HandleSet urlhashes;
     /** best known candidate quality per url hash, used to prefer richer duplicates before final emission */
     private final ConcurrentHashMap<String, Integer> bestResultQualityByUrlHash;
+    /** fuzzy content signatures already emitted; used to suppress near-duplicate pages */
+    private final Set<Long> seenFuzzySignatures;
 
     /** a map from tagging vocabulary names to tagging predicate uris */
     private final Map<String, String> taggingPredicates;
@@ -357,6 +359,7 @@ public final class SearchEvent implements ScoreMapUpdatesListener {
         this.nodeStack = new WeakPriorityBlockingQueue<>(max_results_node, false);
         this.maxExpectedRemoteReferences = new AtomicInteger(0);
         this.expectedRemoteReferences = new AtomicInteger(0);
+        this.seenFuzzySignatures = java.util.Collections.newSetFromMap(new ConcurrentHashMap<>());
         this.excludeintext_image = Switchboard.getSwitchboard().getConfigBool("search.excludeintext.image", true);
 
         // prepare configured search navigation
@@ -2608,13 +2611,18 @@ public final class SearchEvent implements ScoreMapUpdatesListener {
         if (this.urlhashes.has(entry.hash())) {
             return false;
         }
+        // suppress near-duplicate content: skip pages whose fuzzy content signature was already emitted
+        final long fuzzySig = entry.fuzzySignature();
+        if (fuzzySig != 0L && !this.seenFuzzySignatures.add(fuzzySig)) {
+            return false;
+        }
         try {
             this.urlhashes.putUnique(entry.hash());
-            return true;
         } catch (final SpaceExceededException e) {
             ConcurrentLog.logException(e);
             return false;
         }
+        return true;
     }
 
     private void decrementNodeAvailableCount(final URIMetadataNode entry) {

--- a/source/net/yacy/search/ranking/ReferenceOrder.java
+++ b/source/net/yacy/search/ranking/ReferenceOrder.java
@@ -27,6 +27,7 @@
 package net.yacy.search.ranking;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -57,14 +58,22 @@ public class ReferenceOrder {
     private final ConcurrentScoreMap<String> doms; // collected for "authority" heuristic
     private final RankingProfile ranking;
     private final String language;
+    private final Map<String, Long> demotedHostHashes; // hosthash -> divisor
+    private final Map<String, Long> demotedWords;      // word/phrase -> divisor
 
     public ReferenceOrder(final RankingProfile profile, final String language) {
+        this(profile, language, Collections.emptyMap(), Collections.emptyMap());
+    }
+
+    public ReferenceOrder(final RankingProfile profile, final String language, final Map<String, Long> demotedHostHashes, final Map<String, Long> demotedWords) {
         this.min = null;
         this.max = null;
         this.ranking = profile;
         this.doms = new ConcurrentScoreMap<String>();
         this.maxdomcount = 0;
         this.language = language;
+        this.demotedHostHashes = demotedHostHashes;
+        this.demotedWords = demotedWords;
     }
 
     public BlockingQueue<WordReferenceVars> normalizeWith(final ReferenceContainer<WordReference> container, long maxtime, final boolean local) {
@@ -210,6 +219,25 @@ public class ReferenceOrder {
         }
     }
 
+    /** Returns the score divisor for the given hosthash, or 1 if not demoted. */
+    public long getDemotionDivisor(final String hostHash) {
+        if (this.demotedHostHashes.isEmpty()) return 1L;
+        final Long d = this.demotedHostHashes.get(hostHash);
+        return d != null ? d : 1L;
+    }
+
+    /** Returns the score divisor for the first matching demoted word/phrase, or 1 if none match. */
+    public long getDemotionDivisorByWords(final String url, final String title, final String description) {
+        if (this.demotedWords.isEmpty()) return 1L;
+        final String haystack = (url == null ? "" : url.toLowerCase(java.util.Locale.ROOT))
+                + " " + (title == null ? "" : title.toLowerCase(java.util.Locale.ROOT))
+                + " " + (description == null ? "" : description.toLowerCase(java.util.Locale.ROOT));
+        for (final Map.Entry<String, Long> entry : this.demotedWords.entrySet()) {
+            if (haystack.contains(entry.getKey())) return entry.getValue();
+        }
+        return 1L;
+    }
+
     public int authority(final String hostHash) {
         assert hostHash.length() == 6;
         return (this.doms.get(hostHash) << 8) / (1 + this.maxdomcount);
@@ -261,9 +289,11 @@ public class ReferenceOrder {
 
         //if (searchWords != null) r += (yacyURL.probablyWordURL(t.urlHash(), searchWords) != null) ? 256 << ranking.coeff_appurl : 0;
 
+        final long hostDivisor = getDemotionDivisor(t.hosthash());
+        if (hostDivisor > 1L) return r / hostDivisor;
         return r; // the higher the number the better the ranking.
     }
-    
+
     public long cardinal(final URIMetadataNode t) {
         // the normalizedEntry must be a normalized indexEntry
         assert t != null;
@@ -292,6 +322,8 @@ public class ReferenceOrder {
            + ((flags.get(Tokenizer.flag_cat_hasvideo))     ? 255 << this.ranking.coeff_cathasvideo        : 0)
            + ((flags.get(Tokenizer.flag_cat_hasapp))       ? 255 << this.ranking.coeff_cathasapp          : 0)
            + ((this.language.equals(t.language())) ? 255 << this.ranking.coeff_language    : 0);
+        final long hostDivisor = getDemotionDivisor(t.hosthash());
+        if (hostDivisor > 1L) return r / hostDivisor;
         return r; // the higher the number the better the ranking.
     }
 


### PR DESCRIPTION
Add per-host and per-word score demotion to RWI ranking
                                                                                                                                                                                        
  Adds fine-grained score demotion to the RWI ranking configuration page (/RankingRWI_p.html), allowing administrators to push unwanted results toward the end of search results without
   removing them from the index entirely.                                                                                                                                               
   
  Changes                                                                                                                                                                               
                                                            
  Demoted Hosts — enter one hostname per line to divide its ranking score by a configurable divisor (default 100). Demotion is automatically suppressed when any significant label of   
  the hostname appears in the search query. Applies to both the RWI and Solr result paths.
                                                                                                                                                                                        
  Demoted Words — enter one word or quoted phrase per line to demote any result whose URL, title, or description contains that term. Supports an optional custom divisor per entry (e.g.
   "adult services" 500). Applies to the Solr result path.
                                                                                                                                                                                        
  Both lists support an optional trailing divisor on each line:                                                                                                                         
  example.com 500
  spammy-site.org                                                                                                                                                                       
  "unwanted phrase" 1000                                    
  keyword                                                                                                                                                                               
  Lines without a divisor default to 100.
                                                                                                                                                                                        
  Configuration                                                                                                                                                                         
   
  Settings are stored in yacy.conf under:                                                                                                                                               
  - search.ranking.rwi.demotedhosts                         
  - search.ranking.rwi.demotedwords 