### PR TITLE
Fix setting of public port different from YaCy port

### DIFF
--- a/defaults/yacy.init
+++ b/defaults/yacy.init
@@ -19,6 +19,11 @@ port.ssl = 8443
 # port to listen for a shutdown signal ( -1 = disable use of a shutdown port, 8005 = recommended default )
 port.shutdown = -1
 
+# port communicated to peers for connections
+# This setting is intended for cases where YaCy listens on e.g. port 8090, but should be connected to
+# by peers through e.g. port 443.
+port.public = 
+
 # use UPnP [true/false]
 upnp.enabled = true
 # remote host on UPnP device (for more than one connection)

--- a/defaults/yacy.init
+++ b/defaults/yacy.init
@@ -552,7 +552,7 @@ debug.snippets.statistics.enabled=false
 #staticIP if you have a static IP, you can use this setting
 staticIP=
 
-#publicPort if you use a different port to access YaCy than the one it listens on, you can use this setting
+#publicPort this setting is deprecated in favour of port.public
 publicPort=
 
 # each time YaCy starts up, it can trigger the local browser to show the

--- a/source/net/yacy/htroot/SettingsAck_p.java
+++ b/source/net/yacy/htroot/SettingsAck_p.java
@@ -219,9 +219,8 @@ public class SettingsAck_p {
             try {
                 final Integer pport = Integer.parseInt(publicPort);
                 if(pport < 65535 && pport >= 0) {
-                    serverCore.usePublicPort = true;
-                    sb.peers.mySeed().setPort(pport);
-                    env.setConfig(SwitchboardConstants.SERVER_PUBLICPORT, publicPort);
+                    env.setConfig(SwitchboardConstants.SERVER_PORT_PUBLIC, pport);
+                    sb.updateMySeed();
                 }
             } catch (final NumberFormatException e) {
                 // noop

--- a/source/net/yacy/htroot/Settings_p.java
+++ b/source/net/yacy/htroot/Settings_p.java
@@ -95,7 +95,7 @@ public final class Settings_p {
 
         prop.putHTML("peerName", sb.peers.mySeed().getName());
         prop.putHTML("staticIP", env.getConfig("staticIP", ""));
-	prop.putHTML("publicPort", env.getConfig("publicPort",""));
+        prop.putHTML("publicPort", env.getConfig(SwitchboardConstants.SERVER_PORT_PUBLIC,""));
         prop.putHTML("fileHost", env.getConfig("fileHost", "localpeer"));
         String peerLang = env.getConfig("locale.language", "default");
         if (peerLang.equals("default")) peerLang = "en";

--- a/source/net/yacy/migration.java
+++ b/source/net/yacy/migration.java
@@ -106,6 +106,15 @@ public class migration {
                 ConcurrentLog.config("MIGRATION", "disabled https support (reason: port already used)");
             }
         }
+
+        // migrating from old publicPort setting to new port.public
+        int publicPort = sb.getConfigInt(SwitchboardConstants.SERVER_PUBLICPORT, -1);
+        int portDotPublic = sb.getConfigInt(SwitchboardConstants.SERVER_PORT_PUBLIC, -1);
+        if (portDotPublic < 1 && publicPort > 0) {
+            // publicPort is set, port.public is not
+            ConcurrentLog.info("MIGRATION", "Migrating from publicPort to port.public setting");
+            sb.setConfig(SwitchboardConstants.SERVER_PORT_PUBLIC, publicPort);
+        }
     }
     /*
      * remove the static defaultfiles. We use them through a overlay now.

--- a/source/net/yacy/peers/Seed.java
+++ b/source/net/yacy/peers/Seed.java
@@ -1243,7 +1243,7 @@ public class Seed implements Cloneable, Comparable<Seed>, Comparator<Seed>
         final Seed newSeed = new Seed(hashs);
 
         // now calculate other information about the host
-        final int port = Switchboard.getSwitchboard().getPublicPort(SwitchboardConstants.SERVER_PORT, 8090); //get port from config
+        final int port = Switchboard.getSwitchboard().getPublicPort(false); //get port from config
         newSeed.dna.put(Seed.NAME, defaultPeerName() );
         newSeed.dna.put(Seed.PORT, Integer.toString(port));
         return newSeed;

--- a/source/net/yacy/search/Switchboard.java
+++ b/source/net/yacy/search/Switchboard.java
@@ -4405,7 +4405,7 @@ public final class Switchboard extends serverSwitch {
     private static long indeSizeCache = 0;
     private static long indexSizeTime = 0;
     public void updateMySeed() {
-        this.peers.mySeed().put(Seed.PORT, Integer.toString(this.getPublicPort(SwitchboardConstants.SERVER_PORT, 8090)));
+        this.peers.mySeed().put(Seed.PORT, Integer.toString(this.getPublicPort(false)));
 
         //the speed of indexing (pages/minute) of the peer
         final long uptime = (System.currentTimeMillis() - this.startupTime) / 1000;
@@ -4433,7 +4433,7 @@ public final class Switchboard extends serverSwitch {
         mySeed.setFlagAcceptRemoteCrawl(this.getConfigBool(SwitchboardConstants.CRAWLJOB_REMOTE, false));
         mySeed.setFlagAcceptRemoteIndex(this.getConfigBool(SwitchboardConstants.INDEX_RECEIVE_ALLOW, true));
         mySeed.setFlagSSLAvailable(this.getHttpServer() != null && this.getHttpServer().withSSL() && this.getConfigBool("server.https", false));
-        if (mySeed.getFlagSSLAvailable()) mySeed.put(Seed.PORTSSL, Integer.toString(this.getPublicPort(SwitchboardConstants.SERVER_SSLPORT, 8443)));
+        if (mySeed.getFlagSSLAvailable()) mySeed.put(Seed.PORTSSL, Integer.toString(this.getPublicPort(true)));
 
         // set local ips
         final String staticIP = this.getConfig(SwitchboardConstants.SERVER_STATICIP, "");

--- a/source/net/yacy/search/SwitchboardConstants.java
+++ b/source/net/yacy/search/SwitchboardConstants.java
@@ -63,7 +63,8 @@ public final class SwitchboardConstants {
     public static final String SERVER_SSLPORT               = "port.ssl"; // port for https
     public static final String SERVER_SHUTDOWNPORT          = "port.shutdown"; // local port to listen for a shutdown signal (0 <= disabled)
     public static final String SERVER_STATICIP              = "staticIP"; // static IP of http server
-    public static final String SERVER_PUBLICPORT            = "publicPort";
+    public static final String SERVER_PUBLICPORT            = "publicPort"; // deprecated, replace by SERVER_PORT_PUBLIC
+    public static final String SERVER_PORT_PUBLIC           = "port.public"; // public port send to peers to connect to this instance
 
     public static final String PUBLIC_SEARCHPAGE            = "publicSearchpage";
 

--- a/source/net/yacy/server/serverCore.java
+++ b/source/net/yacy/server/serverCore.java
@@ -39,6 +39,5 @@ public final class serverCore {
     public static final String LF_STRING = UTF8.String(new byte[]{LF});
 
     public static boolean useStaticIP = false;
-    public static boolean usePublicPort = false;
 
 }

--- a/source/net/yacy/server/serverSwitch.java
+++ b/source/net/yacy/server/serverSwitch.java
@@ -227,15 +227,27 @@ public class serverSwitch {
      *
      * @see #getLocalPort()
      */
-    public int getPublicPort(final String key, final int dflt) {
-
-        if (this.isConnectedViaUpnp && this.upnpPortMap.containsKey(key)) {
-            return this.upnpPortMap.get(key).intValue();
+    public int getPublicPort(final boolean useSSL) {
+        int publicPort = this.getConfigInt(SwitchboardConstants.SERVER_PORT_PUBLIC, -1);
+        if (publicPort > 0) {
+            return publicPort;
         }
-
-        // TODO: add way of setting and retrieving port for manual NAT
-
-        return this.getConfigInt(key, dflt);
+        else {
+            String portKey = "";
+            int portDefault = 0;
+            if (useSSL) {
+                portKey = SwitchboardConstants.SERVER_SSLPORT;
+                portDefault = 8443;
+            }
+            else {
+                portKey = SwitchboardConstants.SERVER_PORT;
+                portDefault = 8443;
+            }
+            if (this.isConnectedViaUpnp && this.upnpPortMap.containsKey(portKey)) {
+                return this.upnpPortMap.get(portKey).intValue();
+            }
+            return this.getConfigInt(portKey, portDefault);
+        }
     }
 
     /**


### PR DESCRIPTION
This is a fix for #791.

I've had a look at the code, and it looks like the `getPublicPort` function was already used pretty consistently to get the public port send to peers, and didn't seem to be used for anything else. But it always expected the config key of the port setting to be handed in as an argument.

Instead of continuing that, I rewrote the function to instead only receive whether SSL is in use or not, and then decide where to fetch the port internally, doing the following:

- If `SERVER_PORT_PUBLIC` is set, return that value
- If SSL is used:
  - Return `SERVER_SSLPORT` from config or from UPnP map
- If SSL is not used:
  - Return `SERVER_PORT` from config or from UPnP map

I've decided to introduce the new `SERVER_PORT_PUBLIC`/`port.public` setting instead of re-using the `publicPort` setting because for some reason, setting `publicPort` via the env variable `YACY_PUBLICPORT` did not work, and I'm still not sure why.

To make migration easier, I also introduced a migration step: If `publicPort` is set and `port.public` is not, `port.public` is automatically set to the value of `publicPort`.

One last point is my change in the `SettingsAck_p.java` file. I changed the code to call `updateMySeed`, because at least for me, the old way with just setting the seed's port didn't do anything, at least in all the setups I've tried, while calling `updateMySeed` updated the port send to peers for connections as expected.

Once I've got the okay about the introduction of the new `port.public`, I would also be happy to create another PR for the website to update the docs.