### PR TITLE
Remove unused bindPort setting

### DIFF
--- a/defaults/yacy.init
+++ b/defaults/yacy.init
@@ -24,13 +24,6 @@ upnp.enabled = true
 # remote host on UPnP device (for more than one connection)
 upnp.remoteHost =
 
-#sometimes you may want yacy to bind to another port, than the one reachable from outside.
-#then set bindPort to the port yacy should bind on, and port to the port, visible from outside
-#to run yacy on port 8090, reachable from port 80, set bindPort=8090, port=80 and use
-#iptables -t nat -A PREROUTING -p tcp -s 192.168.24.0/16 --dport 80 -j DNAT --to 192.168.24.1:8090
-#(of course you need to customize the ips)
-bindPort = 
-
 # TLS/SSL support:
 #
 # For a German manual see http://yacy-websuche.de/wiki/index.php/De:Interface%C3%9CberHTTPS


### PR DESCRIPTION
Hi YaCy team,

while trying to figure out how to have my local instance listen on one port but communicate another port to external peers for connections, I got thoroughly confused by the `bindPort` setting and its documentation comment. I tried to set up my instance as described, but to no effect at all.

Grepping for `bindPort` in the repo then showed that the identifier only appears in the `yacy.init` file, so I assume that it is
entirely unused and can be removed, to avoid future confusion.

I will also remove it from the config docs on the website in another PR.