### PR TITLE
Fix broken YaCy version string for containerized deployments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-.git
 .github
 DATA*
 RELEASE

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,10 @@ RUN for i in 1 2 3; do \
 # set current working dir & copy sources
 WORKDIR /opt
 COPY . /opt/yacy_search_server/
-RUN ant compile -f /opt/yacy_search_server/build.xml
+# .git dir deleted here because .git is needed during the build to deterime the version,
+# but isn't required at runtime
+RUN ant compile -f /opt/yacy_search_server/build.xml \
+    && rm -fr /opt/yacy_search_server/.git
 
 # Set initial admin password: "yacy" (encoded with custom yacy md5 function net.yacy.cora.order.Digest.encodeMD5Hex())
 RUN sed -i "/adminAccountBase64MD5=/c\adminAccountBase64MD5=MD5:8cffbc0d66567a0987a4aba1ec46d63c" /opt/yacy_search_server/defaults/yacy.init && \

--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -18,7 +18,10 @@ RUN for i in 1 2 3; do \
 # compile YaCy
 WORKDIR /opt
 COPY . /opt/yacy_search_server/
-RUN ant compile -f /opt/yacy_search_server/build.xml
+# .git dir deleted here because .git is needed during the build to deterime the version,
+# but isn't required at runtime
+RUN ant compile -f /opt/yacy_search_server/build.xml \
+    && rm -fr /opt/yacy_search_server/.git
 
 # Set initial admin password: "yacy" (encoded with custom yacy md5 function net.yacy.cora.order.Digest.encodeMD5Hex())
 RUN sed -i "/adminAccountBase64MD5=/c\adminAccountBase64MD5=MD5:8cffbc0d66567a0987a4aba1ec46d63c" /opt/yacy_search_server/defaults/yacy.init && \

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -16,7 +16,10 @@ RUN apk add --no-cache curl git apache-ant
 # set current working dir & copy sources
 WORKDIR /opt
 COPY . /opt/yacy_search_server/
-RUN ant compile -f /opt/yacy_search_server/build.xml
+# .git dir deleted here because .git is needed during the build to deterime the version,
+# but isn't required at runtime
+RUN ant compile -f /opt/yacy_search_server/build.xml \
+    && rm -fr /opt/yacy_search_server/.git
 
 # Set initial admin password: "yacy" (encoded with custom yacy md5 function net.yacy.cora.order.Digest.encodeMD5Hex())
 RUN sed -i "/adminAccountBase64MD5=/c\adminAccountBase64MD5=MD5:8cffbc0d66567a0987a4aba1ec46d63c" /opt/yacy_search_server/defaults/yacy.init && \

--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -18,12 +18,16 @@ RUN apt-get update && apt-get install -yq curl wkhtmltopdf imagemagick xvfb ghos
 WORKDIR /opt
 COPY . /opt/yacy_search_server/
 
+# .git dir deleted here because .git is needed during the build to deterime the version,
+# but isn't required at runtime
+RUN ant compile -f /opt/yacy_search_server/build.xml \
 RUN rm -rf /opt/yacy_search_server/.git && \
     apt-get update && \
 	apt-get install -yq ant && \
 	ant compile -f /opt/yacy_search_server/build.xml && \
 	apt-get purge -yq --auto-remove ant && \
 	apt-get clean && \
+  rm -fr /opt/yacy_search_server/.git && \
 	rm -rf /var/lib/apt/lists/*
 
 # Set initial admin password: "yacy" (encoded with custom yacy md5 function net.yacy.cora.order.Digest.encodeMD5Hex())


### PR DESCRIPTION
I observed my peer's version string to look something like this:
````
yacy_v1.941_fatal: not a git repository (or any of the parent directories): .gitfatal: not a git repository (or any of the parent directories): .git_fatal: not a git repository (or any of the parent directories): .git
````

And looking at [yacystats](https://yacystats.de), it seemed to not just be me. Looking at the Dockerfiles, it was simply because the `.git` directory was excluded via the `.dockerignore`. I removed it from the ignore, and then had to add a a manual `rm -fr` to the builds so the `.git` dir doesn't become part of the final image.

One note on that manual `rm -rf`: I initially tried to use the `--exclude` option of the `COPY` statement, but for some reason that didn't work in my Podman/Buildah setup, hence the manual `rm -fr`. I will investigate that issue separately and make a new PR using `--exclude` on the COPY should I find a fix.

This fixes #796 