### PR TITLE
Fix env vars for camelCase settings

### DIFF
--- a/source/net/yacy/server/serverSwitch.java
+++ b/source/net/yacy/server/serverSwitch.java
@@ -133,19 +133,12 @@ public class serverSwitch {
         // Read system properties and set all variables that have a prefix "yacy.".
         // This will make it possible that settings can be overwritten with environment variables.
         // Do this i.e. with "export YACY_PORT=8091 && ./startYACY.sh"
-        for (final Map.Entry<Object, Object> entry: System.getProperties().entrySet()) {
-            final String yacykey = (String) entry.getKey();
-            if (yacykey.startsWith("YACY_")) {
-                key = yacykey.substring(5).toLowerCase().replace('_', '.');
-                if (this.configProps.containsKey(key)) this.configProps.put(key, (String) entry.getValue());
-            }
-        }
-        for (final Map.Entry<String, String> entry: System.getenv().entrySet()) {
-            final String yacykey = entry.getKey();
-            if (yacykey.startsWith("YACY_")) {
-                key = yacykey.substring(5).toLowerCase().replace('_', '.');
-                if (this.configProps.containsKey(key)) this.configProps.put(key, entry.getValue());
-            }
+        Properties props = System.getProperties();
+        Map<String, String> envVars = System.getenv();
+        for (final Map.Entry<String, String> entry: this.configProps.entrySet()) {
+            final String expectedKey = "YACY_" + entry.getKey().replace('.', '_').toUpperCase();
+            if (props.containsKey(expectedKey)) this.configProps.put(entry.getKey(), props.getProperty(expectedKey));
+            if (envVars.containsKey(expectedKey)) this.configProps.put(entry.getKey(), envVars.get(expectedKey));
         }
 
         // save result; this may initially create a config file after


### PR DESCRIPTION
Hi YaCy team,

This PR relates to #794 

While setting up YaCy with the Docker image in my k8s cluster, I found that environment variables only work for settings like `server.https`, which consist of all lower letters (and dots) only. But for settings like `browserPopUpTrigger`, the environment variable `YACY_BROWSERPOPUPTRIGGER` would be ignored.

It turns out that that that's because during setup, the environment variable is changed to all lower case to find the related config key, and that doesn't work for camelCase keys, as they aren't found.

This PR fixes the issue. As we can't derive camelCase names from the all-caps names of the environment variables, I decided to rewrite the loops a bit. I'm now looping over all entries in the `configProps` map, and check for each entry whether there is a corresponding env variable or system property. To not iterate over all configs twice, once for env variables and once for system properties, I combined them into the same loop. The order of precedence, with env variables overwriting system properties, is preserved.

One question I've got: I will admit that I haven't worked with Java applications in a very long time, but is checking the System properties actually useful here? Are those generally used for settings when deploying an app?

I've done some local testing with this commit, checking whether `camelCase` settings now work, and whether `all.lower.cased` settings still work, and both succeeded.