### PR TITLE
Close owned remote Solr HTTP clients

### DIFF
--- a/source/net/yacy/cora/federate/solr/instance/RemoteInstance.java
+++ b/source/net/yacy/cora/federate/solr/instance/RemoteInstance.java
@@ -101,6 +101,9 @@ public class RemoteInstance implements SolrInstance {
     
     /** HTTP client used to request the Solr server */
     private final HttpClient client;
+
+    /** When true, this instance owns the HTTP client and must close it. */
+    private final boolean closeClientOnClose;
     
     /** Default Solr core name */
     private final String defaultCoreName;
@@ -251,9 +254,11 @@ public class RemoteInstance implements SolrInstance {
         }
         if (solraccount.length() > 0) {
             this.client = buildCustomHttpClient(timeout, u, solraccount, solrpw, host, trustSelfSignedOnAuthenticatedServer, maxBytesPerResponse);
+            this.closeClientOnClose = false;
         } else if(u.isHTTPS()){
         	/* Here we must trust self-signed certificates as most peers with SSL enabled use such certificates */
         	this.client = buildCustomHttpClient(timeout, u, solraccount, solrpw, host, true, maxBytesPerResponse);
+            this.closeClientOnClose = false;
         } else {
         	/* Build a http client using the Solr utils as in the HttpSolrClient constructor implementation. 
         	 * The main difference is that a shared connection manager is used (configured in the buildConnectionManager() function) */
@@ -269,6 +274,7 @@ public class RemoteInstance implements SolrInstance {
             
             
             this.client = HttpClientUtil.createClient(params);
+            this.closeClientOnClose = true;
             if(this.client instanceof org.apache.http.impl.client.DefaultHttpClient) {
             	if(this.client.getParams() != null) {
             		/* Set the maximum time to get a connection from the shared connections pool */
@@ -560,6 +566,9 @@ public class RemoteInstance implements SolrInstance {
 				solrClient.close();
 			} catch (final IOException ignored) {
 			}
+		}
+		if (this.closeClientOnClose) {
+			HttpClientUtil.close(this.client);
 		}
 	}
     


### PR DESCRIPTION
## Summary

Remote Solr searches can create Apache/Solr HTTP clients with their own connection-evictor threads. RemoteInstance.close() already closes the Solr clients, but it did not close the underlying HTTP client created through HttpClientUtil.createClient(params). On busy peers this can leave many Connection evic threads behind and eventually exhaust native thread creation.

This patch tracks whether a RemoteInstance owns that Solr-created HTTP client and closes it from RemoteInstance.close().

## Validation

- ant compile
- Live validation on two YaCy nodes that had the patch deployed:
  - dev node: stayed at 3 Connection evic threads after overnight use
  - Server50: stayed at 3 Connection evic threads after restart and live global searches

I also attempted ant compileTest; in this checkout it fails in unrelated existing test sources before exercising this change: RemoteSolrSmoke, SolrSelectServletTest, NetworkGraphTest.