### PR TITLE
Fix unresolved workload names in PerformanceQueues

### DIFF
--- a/htroot/PerformanceQueues_p.html
+++ b/htroot/PerformanceQueues_p.html
@@ -171,7 +171,7 @@
 	      </tr>
 	      #{pool}#
 	      <tr class="TableCellDark">
-	        <td align="left">#(incomingRequests)##[name]#::Incoming HTTP Requests#(/incomingRequests)#</td>
+	        <td align="left">#[name]#</td>
 	        <td align="right"><input name="#[name]#_maxActive" type="text" size="8" maxlength="8" value="#[maxActive]#" /></td>
 	        <td align="right">#[numActive]#</td>
 	      </tr>


### PR DESCRIPTION

Fixes -UNRESOLVED_PATTERN- being displayed for Crawler Pool and Robots.txt Pool on PerformanceQueues_p.html after the active HTTP request accounting changes. [#810](https://github.com/yacy/yacy_search_server/issues/810)

The backend already provides the correct #[name]# for each pool, including Incoming HTTP Requests, so the conditional template expression is unnecessary.

Tested on current master b1fd3b3185.