### PR TITLE
Fix language preference cookie response header compile error

### DIFF
--- a/source/net/yacy/htroot/yacysearch.java
+++ b/source/net/yacy/htroot/yacysearch.java
@@ -663,9 +663,17 @@ public class yacysearch {
             if (languageFromParam) {
                 final ResponseHeader outgoingHeader = prop.getOutgoingHeader();
                 if (modifier.language != null) {
-                    outgoingHeader.setCookie("yacy-language", "lang_" + modifier.language, 365 * 24 * 60 * 60, "/", null, false);
+                    outgoingHeader.add(
+                        HeaderFramework.SET_COOKIE,
+                        "yacy-language=lang_" + modifier.language +
+                        "; Max-Age=" + (365 * 24 * 60 * 60) +
+                        "; Path=/"
+                    );
                 } else {
-                    outgoingHeader.setCookie("yacy-language", "", 0, "/", null, false);
+                    outgoingHeader.add(
+                        HeaderFramework.SET_COOKIE,
+                        "yacy-language=; Max-Age=0; Path=/"
+                    );
                 }
                 prop.setOutgoingHeader(outgoingHeader);
             }


### PR DESCRIPTION
## Summary
AI helped me...

Fixes a compilation error in `yacysearch.java` caused by calls to a
non-existent `ResponseHeader.setCookie()` method.

The language preference code introduced in commit `11425263d4`
uses:

    outgoingHeader.setCookie(...)

However, `ResponseHeader` does not provide a `setCookie()` method.

This causes a clean checkout of the current YaCy master branch to fail
during compilation with:

    error: cannot find symbol
    outgoingHeader.setCookie(...)
                  ^
    symbol: method setCookie(...)

## Fix

Use YaCy's existing `HeaderFramework.SET_COOKIE` response header support:

    outgoingHeader.add(
        HeaderFramework.SET_COOKIE,
        ...
    );

This preserves the intended `yacy-language` cookie functionality without
adding a new API to `ResponseHeader`.

## Testing

Reproduced on a clean checkout of upstream YaCy master.

Before the fix:

    BUILD FAILED
    yacysearch.java:666: error: cannot find symbol
    yacysearch.java:668: error: cannot find symbol

The parent revision builds successfully, confirming the regression.

After applying this fix:

    BUILD SUCCESSFUL

Runtime testing also confirms setting the language cookie:

    Set-Cookie: yacy-language=lang_en; Max-Age=31536000; Path=/

and clearing the language preference:

    Set-Cookie: yacy-language=; Max-Age=0; Path=/

Tested with:

    curl -i "http://127.0.0.1:8091/yacysearch.html?query=test&lr=lang_en"

and:

    curl -i "http://127.0.0.1:8091/yacysearch.html?query=test&lr="

The language parameter path was also verified to execute with
`languageFromParam=true`.