### PR TITLE
Add action controls above Automation table

### DIFF
--- a/htroot/Automation_p.html
+++ b/htroot/Automation_p.html
@@ -58,6 +58,31 @@ To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index
 	  <input type="hidden" name="transactionToken" value="#[transactionToken]#"/>
       <fieldset>
       <legend>Recorded Actions</legend>
+
+      <!-- Duplicate action controls at the top of the recorded actions list.
+           These trigger the original controls at the bottom of the form,
+           avoiding duplicate submitted field names. -->
+      <div class="form-group col-sm-12" style="margin-top:10px; margin-bottom:10px;">
+        <button type="button" class="btn btn-success" onclick="document.getElementById('execrowsBottom').click();">Execute Selected Actions</button>&nbsp;&nbsp;&nbsp;
+        <button type="button" class="btn btn-danger" onclick="document.getElementById('deleterowsBottom').click();">Delete Selected Actions</button>&nbsp;&nbsp;&nbsp;
+      </div>
+      <div class="form-group col-sm-6">
+        <button type="button" class="btn btn-warning" style="float:left;" onclick="document.getElementById('deleteoldtimeBottom').value=document.getElementById('deleteoldtimeTop').value; document.getElementById('deleteoldBottom').click();">Delete all Actions which had been created before </button>
+        <select id="deleteoldtimeTop" class="form-control selectWidth input-sm" style="width:auto;">
+          <option value="1">1 day</option><option value="2">2 days</option><option value="3">3 days</option>
+          <option value="4">4 days</option><option value="5">5 days</option><option value="6">6 days</option>
+          <option value="7">1 week</option><option value="14">2 weeks</option><option value="21">3 weeks</option>
+          <option value="30">1 month</option><option value="60" selected="selected">2 months</option><option value="90">3 months</option>
+          <option value="180">6 months</option><option value="270">9 months</option>
+          <option value="365">1 year</option><option value="730">2 years</option>
+        </select>
+      </div>
+      #(hasEditableNextExecDate)#::
+      <div class="form-group col-sm-6">
+        <button type="button" class="btn btn-default" onclick="document.getElementById('submitNextExecDatesBottom').click();">Apply edited next execution dates</button>
+      </div>
+      #(/hasEditableNextExecDate)#
+      <div style="clear:both;"></div>
       <br />
       <span id="resCounter" style="display: inline;">
       #(navigation)#
@@ -235,12 +260,12 @@ To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index
       <input type="hidden" name="current_pk" id="current_pk" value="" />
       <input type="hidden" name="num" value="#[num]#" />
       <div class="form-group col-sm-12">
-        <input type="submit" name="execrows" value="Execute Selected Actions" class="btn btn-success"/>&nbsp;&nbsp;&nbsp;
-        <input type="submit" name="deleterows" value="Delete Selected Actions" class="btn btn-danger" onclick="return confirm('Confirm Deletion')"/>&nbsp;&nbsp;&nbsp;
+        <input type="submit" id="execrowsBottom" name="execrows" value="Execute Selected Actions" class="btn btn-success"/>&nbsp;&nbsp;&nbsp;
+        <input type="submit" id="deleterowsBottom" name="deleterows" value="Delete Selected Actions" class="btn btn-danger" onclick="return confirm('Confirm Deletion')"/>&nbsp;&nbsp;&nbsp;
       </div>
       <div class="form-group col-sm-6">
-        <input type="submit" name="deleteold" value="Delete all Actions which had been created before " class="btn btn-warning" style="float:left;" onclick="return confirm('Confirm Deletion')"/>
-        <select name="deleteoldtime" class="form-control selectWidth input-sm" style="width:auto;">
+        <input type="submit" id="deleteoldBottom" name="deleteold" value="Delete all Actions which had been created before " class="btn btn-warning" style="float:left;" onclick="return confirm('Confirm Deletion')"/>
+        <select id="deleteoldtimeBottom" name="deleteoldtime" class="form-control selectWidth input-sm" style="width:auto;">
           <option value="1">1 day</option><option value="2">2 days</option><option value="3">3 days</option>
           <option value="4">4 days</option><option value="5">5 days</option><option value="6">6 days</option>
           <option value="7">1 week</option><option value="14">2 weeks</option><option value="21">3 weeks</option>
@@ -251,7 +276,7 @@ To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index
       </div>
       #(hasEditableNextExecDate)#::
       <div class="form-group col-sm-6">
- 		<input type="submit" name="submitNextExecDates" class="btn btn-default" value="Apply edited next execution dates"/>
+ 		<input type="submit" id="submitNextExecDatesBottom" name="submitNextExecDates" class="btn btn-default" value="Apply edited next execution dates"/>
       </div>
       #(/hasEditableNextExecDate)#
       


### PR DESCRIPTION
## Summary
AI helped me

Adds a second set of action controls above the Recorded Actions table on `Automation_p.html`.

The existing controls at the bottom of the table are retained.

## Reason

Recorded actions can contain **very large crawler URL's or domain lists**, making individual rows and the overall table very tall.

With long lists, users may otherwise need to scroll a considerable distance to reach the action controls at the bottom of the page.

Providing the controls at both the top and bottom makes the page easier to use regardless of the user's current position in the Recorded Actions list.

## Implementation

The controls at the top use `type="button"` and trigger the existing submit controls at the bottom of the form.

This avoids adding duplicate submitted field names and keeps the existing server-side handling unchanged.

The top controls provide access to:

* Execute Selected Actions
* Delete Selected Actions
* Delete actions older than the selected age
* Apply edited next execution dates, when available

The original bottom controls remain in place.

## Testing

Tested with recorded crawler actions containing large domain lists.

The top controls correctly trigger the existing bottom submit controls, and the original controls remain available at the bottom of the table.
