### PR TITLE
Show git commit on Console Status and in the release README #466

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -379,6 +379,7 @@
           <include name="NOTICE"/>
       </fileset>
     </copy>
+    <echo file="${release_main}/README.txt" message="YaCy ${releaseVersion}${line.separator}Git commit: ${repository.revision.hash}${line.separator}Release: ${stdReleaseStub}${line.separator}"/>
 
     <!-- copy source code -->
     <copy todir="${release_main}/source">

--- a/help/Status.md
+++ b/help/Status.md
@@ -16,6 +16,8 @@ Console Status is the operational dashboard for the peer. Its Incoming HTTP Requ
 
 Use it first to see identity, uptime, network position, indexing state, and important warnings.
 
+The System Status box lists the YaCy version stub and the git commit of the running build. The same commit is `buildHash` on `/api/version.xml`.
+
 ## What You Can Do Here
 
 - Console Status is the operational dashboard for the peer.
@@ -28,6 +30,8 @@ Monitoring pages read live peer state from queues, logs, network tables, memory 
 
 | Control | Meaning | Values or examples |
 | --- | --- | --- |
+| Git commit | Abbreviated git hash of this build | `#[gitCommit]#` from `yacyBuild.properties` |
+| `/api/version.xml` `buildHash` | Same git hash as System Status | `#[buildHash]#` |
 
 ## Correct Use
 

--- a/htroot/Status_p.inc
+++ b/htroot/Status_p.inc
@@ -5,6 +5,7 @@
 
     <dt>System</dt>
     <dd>YaCy version: #[versionpp]#
+    <div>Git commit: #[gitCommit]#</div>
     #(peerStatistics)#
       Unknown
       ::

--- a/htroot/api/version.xml
+++ b/htroot/api/version.xml
@@ -4,6 +4,6 @@
     <buildDate>#[buildDate]#</buildDate>
     <buildTime>#[buildTime]#</buildTime>
     <buildDateTime>#[buildDateTime]#</buildDateTime>
-    <buildHash>#[buildDateTime]#</buildHash>
+    <buildHash>#[buildHash]#</buildHash>
     <buildVersion>#[buildVersion]#</buildVersion>
 </version>

--- a/locales/de.lng
+++ b/locales/de.lng
@@ -2918,6 +2918,7 @@ Your network configuration is in private mode. Your peer seed will not be publis
 #File: Status_p.inc
 #---------------------------
 System Status==Systemstatus
+Git commit:==Git-Commit:
 Unknown==unbekannt
 Protection==Sicherheit
 password-protected==Passwort-geschützt

--- a/source/net/yacy/htroot/Status.java
+++ b/source/net/yacy/htroot/Status.java
@@ -164,6 +164,7 @@ public class Status
         //final String versionstring = yacyVersion.combined2prettyVersion(sb.getConfig("version","0.1"));
         final String versionstring = yacyBuildProperties.getReleaseStub();
         prop.put("versionpp", versionstring);
+        prop.put("gitCommit", yacyBuildProperties.getRepositoryVersionHash());
         prop.put("java.version", System.getProperty("java.version"));
 
         // place some more hints

--- a/test/java/net/yacy/htroot/api/VersionXmlTest.java
+++ b/test/java/net/yacy/htroot/api/VersionXmlTest.java
@@ -1,0 +1,26 @@
+package net.yacy.htroot.api;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class VersionXmlTest {
+
+    @Test
+    public void versionXmlBuildHashUsesOwnPlaceholder() throws Exception {
+        final String xml = new String(Files.readAllBytes(Paths.get("htroot/api/version.xml")),
+                StandardCharsets.UTF_8);
+        Assert.assertTrue(xml.contains("<buildHash>#[buildHash]#</buildHash>"));
+        Assert.assertFalse(xml.contains("<buildHash>#[buildDateTime]#</buildHash>"));
+    }
+
+    @Test
+    public void statusBoxListsGitCommit() throws Exception {
+        final String html = new String(Files.readAllBytes(Paths.get("htroot/Status_p.inc")),
+                StandardCharsets.UTF_8);
+        Assert.assertTrue(html.contains("Git commit: #[gitCommit]#"));
+    }
+}


### PR DESCRIPTION
I put the build git hash on Console Status as its own Git commit line, and packed the same hash into README.txt in the release tarball so you can read it without starting YaCy.

`/api/version.xml` `buildHash` was wired to the datetime placeholder; it now uses the hash.
